### PR TITLE
feat: add organisms

### DIFF
--- a/src/atoms/text/Text.tsx
+++ b/src/atoms/text/Text.tsx
@@ -53,7 +53,7 @@ const Text = styled.p<TextProps>`
         `;
     }
   }}
-  size: ${({ size }) => size ?? undefined};
+  font-size: ${({ size }) => size ?? undefined};
   text-align: ${({ textAlign }) => textAlign ?? "inherit"};
   color: ${({ color }) => color ?? "inherit"};
 `;

--- a/src/organisms/tagSelect/TagSelect.stories.tsx
+++ b/src/organisms/tagSelect/TagSelect.stories.tsx
@@ -1,0 +1,15 @@
+import { Meta, StoryFn } from "@storybook/react";
+
+import TagSelect from "./TagSelect";
+
+export default {
+  title: "organisms/tagSelect/TagSelect",
+  component: TagSelect,
+} as Meta<typeof TagSelect>;
+
+const Template: StoryFn<typeof TagSelect> = (args) => <TagSelect {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  tags: ["태그1", "태그2", "태그3"],
+};

--- a/src/organisms/tagSelect/TagSelect.tsx
+++ b/src/organisms/tagSelect/TagSelect.tsx
@@ -13,6 +13,10 @@ const TagSelectWrapper = styled.div`
   align-items: center;
   gap: 5px;
   padding: 0 16px;
+  overflow: scroll;
+  > * {
+    flex: 0 0 auto;
+  }
 `;
 
 interface TagSelectProps {

--- a/src/organisms/tagSelect/TagSelect.tsx
+++ b/src/organisms/tagSelect/TagSelect.tsx
@@ -1,0 +1,31 @@
+import styled from "styled-components";
+
+import Tag from "../../molecules/tag/Tag";
+import colorSet from "../../styles/colorSet";
+
+const TagSelectWrapper = styled.div`
+  border-radius: 10px;
+  border: 1.5px solid ${colorSet.primary};
+  height: 48px;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 0 16px;
+`;
+
+interface TagSelectProps {
+  tags: string[];
+  onDelete?: (tag: string) => void;
+}
+
+const TagSelect = ({ tags, onDelete }: TagSelectProps) => {
+  return (
+    <TagSelectWrapper>
+      {tags.map((tag) => (
+        <Tag key={tag} label={tag} onDeleteClick={() => onDelete?.(tag)} />
+      ))}
+    </TagSelectWrapper>
+  );
+};
+
+export default TagSelect;

--- a/src/organisms/tagSelect/TagSelect.tsx
+++ b/src/organisms/tagSelect/TagSelect.tsx
@@ -1,5 +1,7 @@
+import { useEffect, useState } from "react";
 import styled from "styled-components";
 
+import Input from "../../atoms/inputs/input/Input";
 import Tag from "../../molecules/tag/Tag";
 import colorSet from "../../styles/colorSet";
 
@@ -16,14 +18,24 @@ const TagSelectWrapper = styled.div`
 interface TagSelectProps {
   tags: string[];
   onDelete?: (tag: string) => void;
+  onAdd?: (tag: string) => void;
 }
 
-const TagSelect = ({ tags, onDelete }: TagSelectProps) => {
+const TagSelect = ({ tags, onDelete, onAdd }: TagSelectProps) => {
+  const [input, setInput] = useState("");
+
+  useEffect(() => {
+    if (!input.includes(" ")) return;
+    onAdd?.(input.split(" ")[0]);
+    setInput("");
+  }, [input, onAdd]);
+
   return (
     <TagSelectWrapper>
       {tags.map((tag) => (
         <Tag key={tag} label={tag} onDeleteClick={() => onDelete?.(tag)} />
       ))}
+      <Input value={input} onChange={(e) => setInput(e.target.value)} />
     </TagSelectWrapper>
   );
 };

--- a/src/organisms/zabo/TextZabo.stories.tsx
+++ b/src/organisms/zabo/TextZabo.stories.tsx
@@ -1,0 +1,20 @@
+import { Meta, StoryFn } from "@storybook/react";
+
+import TextZabo from "./TextZabo";
+
+export default {
+  title: "organisms/zabo/TextZabo",
+  component: TextZabo,
+} as Meta<typeof TextZabo>;
+
+const Template: StoryFn<typeof TextZabo> = (args) => <TextZabo {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  title: "맥북 프로 주인을 찾습니다.",
+  content:
+    "2월 11일쯤 해동에서 맥북 프로를 분실하신 분을 찾습니다. 24시간 넘게 안 가져가시길래 제가 일단 보관하기로 했고 이렇게 게시글 올립니다. 글 본 분들은 주변에 알려주시고 혹시나 주인분이 보신다면 01044445555로 연락 부탁드립니다.",
+  date: "2023.02.13",
+  viewCount: 119,
+  author: "박시원",
+};

--- a/src/organisms/zabo/TextZabo.tsx
+++ b/src/organisms/zabo/TextZabo.tsx
@@ -25,6 +25,7 @@ interface ContentZaboProps {
   viewCount: number;
   author: string;
   content: string;
+  organization: string;
 }
 
 const TextZabo = ({
@@ -33,6 +34,7 @@ const TextZabo = ({
   viewCount,
   author,
   content,
+  organization,
 }: ContentZaboProps) => {
   return (
     <ZaboWrapper>
@@ -53,7 +55,9 @@ const TextZabo = ({
           조회수 {viewCount}
         </Text>
       </Flex>
-      <Text font={Font.NoticeWriter}>{author}</Text>
+      <Text font={Font.NoticeWriter}>
+        {author} • {organization}
+      </Text>
     </ZaboWrapper>
   );
 };

--- a/src/organisms/zabo/TextZabo.tsx
+++ b/src/organisms/zabo/TextZabo.tsx
@@ -1,0 +1,61 @@
+import Flex from "src/atoms/containers/flex/Flex";
+import styled from "styled-components";
+
+import Text from "../../atoms/text/Text";
+import colorSet from "../../styles/colorSet";
+import Font from "../../styles/font";
+
+const ZaboWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 20px;
+
+  border-radius: 5px;
+  border: 1px solid ${colorSet.secondaryText};
+
+  p {
+    margin: 0;
+  }
+`;
+
+interface ContentZaboProps {
+  title: string;
+  date: string;
+  viewCount: number;
+  author: string;
+  content: string;
+}
+
+const TextZabo = ({
+  title,
+  date,
+  viewCount,
+  author,
+  content,
+}: ContentZaboProps) => {
+  return (
+    <ZaboWrapper>
+      <Text font={Font.NoticeWriter} size="1.875rem">
+        {title}
+      </Text>
+      <Text font={Font.NoticeDes_Medium} size="1.125rem">
+        {content}
+      </Text>
+      <Flex gap="0.25em">
+        <Text font={Font.NoticeDes_Medium} color={colorSet.secondaryText}>
+          {date}
+        </Text>
+        <Text font={Font.NoticeDes_Medium} color={colorSet.secondaryText}>
+          •
+        </Text>
+        <Text font={Font.NoticeDes_Bold} color={colorSet.secondaryText}>
+          조회수 {viewCount}
+        </Text>
+      </Flex>
+      <Text font={Font.NoticeWriter}>{author}</Text>
+    </ZaboWrapper>
+  );
+};
+
+export default TextZabo;

--- a/src/organisms/zabo/Zabo.stories.tsx
+++ b/src/organisms/zabo/Zabo.stories.tsx
@@ -1,0 +1,20 @@
+import { Meta, StoryFn } from "@storybook/react";
+
+import Zabo from "./Zabo";
+
+export default {
+  title: "organisms/zabo/Zabo",
+  component: Zabo,
+} as Meta<typeof Zabo>;
+
+const Template: StoryFn<typeof Zabo> = (args) => <Zabo {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  thumbnailUrl: "https://picsum.photos/200/300",
+  title: "23년도 인포팀 신규 부원 모집",
+  date: "2023.02.13",
+  viewCount: 110,
+  author: "이정우",
+  organization: "INFOTEAM",
+};

--- a/src/organisms/zabo/Zabo.tsx
+++ b/src/organisms/zabo/Zabo.tsx
@@ -1,0 +1,72 @@
+import Flex from "src/atoms/containers/flex/Flex";
+import styled from "styled-components";
+
+import Text from "../../atoms/text/Text";
+import colorSet from "../../styles/colorSet";
+import Font from "../../styles/font";
+
+const ZaboWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+
+  img {
+    border-radius: 5px;
+  }
+
+  p {
+    margin: 0;
+  }
+`;
+
+const Title = styled(Text)`
+  -webkit-line-clamp: 2;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+`;
+Title.defaultProps = {
+  font: Font.NoticeWriter,
+  size: "1.25rem",
+};
+
+interface ZaboProps {
+  title: string;
+  date: string;
+  viewCount: number;
+  author: string;
+  thumbnailUrl: string;
+  organization: string;
+}
+
+const TextZabo = ({
+  title,
+  date,
+  viewCount,
+  author,
+  thumbnailUrl,
+  organization,
+}: ZaboProps) => {
+  return (
+    <ZaboWrapper>
+      <img src={thumbnailUrl} />
+      <Title>{title}</Title>
+      <Flex gap="0.25em">
+        <Text font={Font.NoticeDes_Medium} color={colorSet.secondaryText}>
+          {date}
+        </Text>
+        <Text font={Font.NoticeDes_Medium} color={colorSet.secondaryText}>
+          •
+        </Text>
+        <Text font={Font.NoticeDes_Bold} color={colorSet.secondaryText}>
+          조회수 {viewCount}
+        </Text>
+      </Flex>
+      <Text font={Font.NoticeWriter}>
+        {author} • {organization}
+      </Text>
+    </ZaboWrapper>
+  );
+};
+
+export default TextZabo;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,10 @@
       "@types/*": ["src/@types/*"],
       "@types": ["src/@types"]
     },
-    "typeRoots": ["./node_modules/@types/", "./src/@types/"]
+    "typeRoots": ["./node_modules/@types/", "./src/@types/"],
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]


### PR DESCRIPTION
resolve #12 

자보 컴포넌트의 사이징 처리를 사용하는 쪽으로 위임하는게 깔끔할 것 같아서 해당 형태로 처리했습니다.
자보 컴포넌트를 두개로 분리했습니다 (텍스트만 있는 것, 썸네일이 같이 있는 것)

<img width="361" alt="CleanShot 2023-05-05 at 12 50 24@2x" src="https://user-images.githubusercontent.com/125528915/236374195-7747ef74-74d5-45da-8b07-b4794732b341.png">
<img width="363" alt="CleanShot 2023-05-05 at 12 52 05@2x" src="https://user-images.githubusercontent.com/125528915/236374374-0d4dd8db-955e-4080-b2b3-5a4903f62725.png">
<video src="https://user-images.githubusercontent.com/125528915/236374448-2e7fbd7f-1b97-4d77-8735-f59954fb8f38.mp4">
