### PR TITLE
fix: give gap in top of TextZabo if it shows dday

### DIFF
--- a/src/organisms/zabo/TextZabo.tsx
+++ b/src/organisms/zabo/TextZabo.tsx
@@ -125,7 +125,7 @@ const TextZabo = ({
             WebkitLineClamp: lineClamp,
           }}
         >
-          {dDay > 0 && <Spacer height="1.5rem" />}
+          {dDay > 0 && <Spacer height={isMobile ? "1rem" : "1.5rem"} />}
           {/* title이 50이 넘을 일은 없지만 혹시 모르니 이렇게 처리 */}
           {titleLength > 50 ? title.slice(0, 50) + "..." : title}
         </Text>

--- a/src/organisms/zabo/TextZabo.tsx
+++ b/src/organisms/zabo/TextZabo.tsx
@@ -107,6 +107,7 @@ const TextZabo = ({
 
   const titleLength = title.length;
   const lineClamp = calculateLineClamp(titleLength, origin);
+  const dDay = deadline ? calculateDDay(deadline) : 0;
 
   return (
     <ZaboWrapper
@@ -124,6 +125,7 @@ const TextZabo = ({
             WebkitLineClamp: lineClamp,
           }}
         >
+          {dDay > 0 && <Spacer height="1.5rem" />}
           {/* title이 50이 넘을 일은 없지만 혹시 모르니 이렇게 처리 */}
           {titleLength > 50 ? title.slice(0, 50) + "..." : title}
         </Text>
@@ -182,7 +184,7 @@ const TextZabo = ({
         </Text>
       </Flex>
 
-      {deadline && calculateDDay(deadline) > 0 && (
+      {dDay > 0 && (
         <Flex
           style={{
             position: "absolute",
@@ -191,7 +193,7 @@ const TextZabo = ({
             zIndex: 1,
           }}
         >
-          <DDay dayLeft={calculateDDay(deadline)} />
+          <DDay dayLeft={dDay} />
         </Flex>
       )}
     </ZaboWrapper>


### PR DESCRIPTION
<img width="163" alt="CleanShot 2023-08-28 at 19 03 19@2x" src="https://github.com/gsainfoteam/ziggle-fe/assets/125528915/a0831404-c5ff-45cd-af9d-7ffd0a35dacd">