### PR TITLE
fix: support academic notice

### DIFF
--- a/src/app/components/molecules/Pagination/Pagination.tsx
+++ b/src/app/components/molecules/Pagination/Pagination.tsx
@@ -54,20 +54,23 @@ const Pagination = ({ pages, page }: PaginationProps) => {
         </Button>
       )}
       <div className="w-2 shrink-0" />
-      {[...Array(pages)].map((_, index) => (
-        <Link key={index} href={generateLink(index)}>
-          <Button
-            className={[
-              'h-7 w-7 shrink-0 rounded-lg font-medium md:h-8 md:w-8 md:text-xl',
-              index === page
-                ? 'bg-primary text-white'
-                : 'bg-white text-primary',
-            ].join(' ')}
-          >
-            {index + 1}
-          </Button>
-        </Link>
-      ))}
+      {[...Array(Math.min(pages, 9))]
+        .map((_, index) => index + Math.max(0, page - 4))
+        .filter((index) => index >= 0 && index < pages)
+        .map((index) => (
+          <Link key={index} href={generateLink(index)}>
+            <Button
+              className={[
+                'h-7 w-7 shrink-0 rounded-lg font-medium md:h-8 md:w-8 md:text-xl',
+                index === page
+                  ? 'bg-primary text-white'
+                  : 'bg-white text-primary',
+              ].join(' ')}
+            >
+              {index + 1}
+            </Button>
+          </Link>
+        ))}
       <div className="w-2 shrink-0" />
       {page + 1 !== pages ? (
         <Button animated>

--- a/src/app/components/templates/ResultZabo/ResultImageZabo.tsx
+++ b/src/app/components/templates/ResultZabo/ResultImageZabo.tsx
@@ -51,11 +51,13 @@ const ResultImageZabo = async ({
           }}
         >
           <div className="align-start flex flex-col">
-            <p className={'text-sm font-medium md:text-xl'}>
-              <Trans t={t} i18nKey="zabo.dueAt">
-                {{ dueAt: dayjs(deadline).format('LLL') }}
-              </Trans>
-            </p>
+            {deadline && (
+              <p className={'text-sm font-medium md:text-xl'}>
+                <Trans t={t} i18nKey="zabo.dueAt">
+                  {{ dueAt: dayjs(deadline).format('LLL') }}
+                </Trans>
+              </p>
+            )}
             <p className="text-start text-xl font-bold md:text-3xl">
               {searchQuery ? (
                 <HighlightedText query={searchQuery}>{title}</HighlightedText>

--- a/src/app/components/templates/ResultZabo/ResultTextZabo.tsx
+++ b/src/app/components/templates/ResultZabo/ResultTextZabo.tsx
@@ -41,11 +41,13 @@ const ResultTextZabo = async ({
         }
       >
         <div className="flex flex-col items-start">
-          <div className="mb-1.5 text-lg font-medium">
-            <Trans t={t} i18nKey="zabo.dueAt">
-              {{ dueAt: dayjs(deadline).format('LLL') }}
-            </Trans>
-          </div>
+          {deadline && (
+            <div className="mb-1.5 text-lg font-medium">
+              <Trans t={t} i18nKey="zabo.dueAt">
+                {{ dueAt: dayjs(deadline).format('LLL') }}
+              </Trans>
+            </div>
+          )}
           <div className="text-start text-3xl font-bold">
             {searchQuery ? (
               <HighlightedText query={searchQuery}>{title}</HighlightedText>

--- a/src/app/i18next/locales/en/translation.json
+++ b/src/app/i18next/locales/en/translation.json
@@ -65,7 +65,7 @@
     "clickPoster": "Click on the poster to read more",
     "downloadAll": "Download All",
     "close": "Close",
-    "author": "Author <strong>{{author}}</strong>",
+    "author": "Author <strong>{{- author}}</strong>",
     "createdAt": "Created on {{createdAt}}",
     "views": "{{views}} views",
     "copyLink": {

--- a/src/app/i18next/locales/ko/translation.json
+++ b/src/app/i18next/locales/ko/translation.json
@@ -62,7 +62,7 @@
     "clickPoster": "포스터 클릭하여 자세히 보기",
     "downloadAll": "전체 다운로드하기",
     "close": "닫기",
-    "author": "글쓴이 <strong>{{author}}</strong>",
+    "author": "글쓴이 <strong>{{- author}}</strong>",
     "createdAt": "작성일 {{createdAt}}",
     "views": "조회수 {{views}}",
     "copyLink": {


### PR DESCRIPTION
학사 공지를 지원하면서 수정이 필요한 부분을 수정하였습니다.
* pagination을 최대 9개만 한번에 표시합니다
* NoticeInfo의 author 필드가 i18next에 의해서 escaping 되는데, 이는 Trans 컴포넌트로 인해서 불필요한 조치입니다. 따라서 translation.json `zabo.author`에 있는 interpolation을 [unescape](https://www.i18next.com/translation-function/interpolation#unescape) 처리했습니다.
* 이 PR과는 그렇게 관련이 없지만 ResultZabo에서 deadline이 없음에도 오늘 날짜로 뜨는 버그를 수정했습니다.

![CleanShot 2023-11-24 at 14 26 00@2x](https://github.com/gsainfoteam/ziggle-fe/assets/125528915/029a774c-a416-41df-b882-2b6566a21749)
interpolation과 관련된 이미지 입니다.