### PR TITLE
:bug: Fix bug on adding additional notice

### DIFF
--- a/src/app/[lng]/notice/[id]/AddAdditionalNotice.tsx
+++ b/src/app/[lng]/notice/[id]/AddAdditionalNotice.tsx
@@ -68,7 +68,7 @@ const AddAdditionalNotice = ({
       variables: {
         noticeId,
         body: content,
-        deadline,
+        deadline: hasDeadline ? deadline : originallyHasDeadline,
       },
     });
 
@@ -78,7 +78,7 @@ const AddAdditionalNotice = ({
     }
     const contentId = contents[contents.length - 1].id;
 
-    if (notice && contentId) {
+    if (notice && contentId && supportEnglish) {
       const enNotice = await apolloClient.mutate({
         mutation: ATTACH_INTERNATIONAL_NOTICE,
         variables: {
@@ -87,22 +87,22 @@ const AddAdditionalNotice = ({
           lang: 'en',
           noticeId,
           contentId,
-          deadline,
+          deadline: hasDeadline ? deadline : originallyHasDeadline,
         },
       });
-
-      setContent('');
-      setEnglishContent('');
-
-      Swal.fire({
-        icon: 'success',
-        title: t('write.alerts.submitSuccess'),
-        showConfirmButton: false,
-        timer: 1500,
-      });
-
-      refresh();
     }
+
+    setContent('');
+    setEnglishContent('');
+
+    Swal.fire({
+      icon: 'success',
+      title: t('write.alerts.submitSuccess'),
+      showConfirmButton: false,
+      timer: 1500,
+    });
+
+    refresh();
   };
 
   return (

--- a/src/app/[lng]/notice/[id]/AdditionalNotices.tsx
+++ b/src/app/[lng]/notice/[id]/AdditionalNotices.tsx
@@ -6,21 +6,30 @@ import AddIcon from '@/assets/icons/add.svg';
 import getLocaleContents from '@/utils/getLocaleContents';
 
 interface AdditionalNoticesProps {
-  contents: Content[];
+  mainContent: Content;
+  additionalContents: Content[];
   t: T;
 }
 
 const AdditionalNotices = async ({
-  contents,
+  mainContent,
+  additionalContents,
   t,
   lng,
 }: AdditionalNoticesProps & PropsWithLng) => {
-  const localeContents = getLocaleContents(contents, lng);
-
   return (
     <div className={'flex flex-col gap-4'}>
-      {localeContents.map((content, index) => {
-        return index > 0 ? (
+      {additionalContents.map((content, index) => {
+        const lastDeadline =
+          index > 0
+            ? additionalContents[index - 1].deadline
+            : mainContent.deadline;
+
+        const deadlineChanged = !dayjs(content.deadline).isSame(
+          dayjs(lastDeadline),
+        );
+
+        return (
           <div
             key={`${content.id}+${content.lang}`}
             className="flex flex-col gap-2.5 rounded-xl border-2 border-primary p-4"
@@ -36,34 +45,31 @@ const AdditionalNotices = async ({
             </div>
 
             <div className="ml-8">
-              {index > 0 &&
-                !dayjs(content.deadline).isSame(
-                  dayjs(localeContents[index - 1].deadline),
-                ) && (
-                  <div className="flex items-center gap-3">
-                    <p className={'text-base font-bold'}>
-                      {t('zabo.additionalNotices.deadlineChanged')}
-                    </p>
-                    <p className={'text-base font-medium text-secondaryText'}>
-                      {dayjs(localeContents[index - 1].deadline)
-                        .tz()
-                        .format('LLL')}
-                    </p>
+              {deadlineChanged && (
+                <div className="flex items-center gap-3">
+                  <p className={'text-base font-bold'}>
+                    {t('zabo.additionalNotices.deadlineChanged')}
+                  </p>
+                  <p className={'text-base font-medium text-secondaryText'}>
+                    {dayjs(lastDeadline).tz().isValid()
+                      ? dayjs(lastDeadline).tz().format('LLL')
+                      : t('zabo.additionalNotices.noDeadline')}
+                  </p>
 
-                    <p>▶</p>
+                  <p>▶</p>
 
-                    <p className={'text-base font-medium'}>
-                      {dayjs(content.deadline).tz().format('LLL')}
-                    </p>
-                  </div>
-                )}
+                  <p className={'text-base font-medium'}>
+                    {dayjs(content.deadline).tz().format('LLL')}
+                  </p>
+                </div>
+              )}
             </div>
 
             <div className={'mb-3 ml-8 mt-1'}>
               <p className={'text-base'}>{content.body}</p>
             </div>
           </div>
-        ) : null;
+        );
       })}
     </div>
   );

--- a/src/app/[lng]/notice/[id]/page.tsx
+++ b/src/app/[lng]/notice/[id]/page.tsx
@@ -57,6 +57,13 @@ const DetailedNoticePage = async ({
 
   const localContents = getLocaleContents(notice.contents, lng);
 
+  const mainContent =
+    localContents.find((content) => content.id === 1) ?? localContents[0];
+
+  const additionalContents = localContents.filter(
+    (content) => content.id !== 1,
+  );
+
   const title = localContents[0].title;
 
   const user = await auth();
@@ -92,10 +99,15 @@ const DetailedNoticePage = async ({
           lng={lng}
         />
         <div className="h-5" />
-        <Content content={localContents[0].body} />
+        <Content content={mainContent?.body ?? ''} />
 
         <div className="h-10" />
-        <AddtionalNotices contents={localContents} t={t} lng={lng} />
+        <AddtionalNotices
+          additionalContents={additionalContents}
+          mainContent={mainContent}
+          t={t}
+          lng={lng}
+        />
 
         {user && user.id === notice.authorId && isAdditionalNoticeShow && (
           <>

--- a/src/app/i18next/locales/en/translation.json
+++ b/src/app/i18next/locales/en/translation.json
@@ -88,6 +88,7 @@
       "title": "Additional Notices",
       "deadlineChanged": "Deadline Changed",
       "addAdditionalNotice": "Write an additional notice",
+      "noDeadline": "No Deadline",
       "changeDeadline": "Change Deadline",
       "koreanAdditionalNotice": "Korean Additional Notice",
       "englishAdditionalNotice": "English Additional Notice",

--- a/src/app/i18next/locales/ko/translation.json
+++ b/src/app/i18next/locales/ko/translation.json
@@ -85,6 +85,7 @@
       "title": "추가 공지",
       "deadlineChanged": "마감시간 변경",
       "addAdditionalNotice": "추가 공지 작성하기",
+      "noDeadline": "마감시간 없음",
       "changeDeadline": "마감시간 변경하기",
       "koreanAdditionalNotice": "한국어 추가 공지",
       "englishAdditionalNotice": "영어 추가 공지",


### PR DESCRIPTION
버그: 한국어 공지 작성 -> 한국어 추가공지 작성 -> en에서 한국어 공지 내용 안보임

이유: 한국어 추가공지 작성 단계에서 빈 영어공지를 같이 보냄 -> 이제 영어공지를 지원한다고 인식 -> 한국어 메인공지를 필터링해버림

해결: 추가공지 작성 시 영어공지를 항상 같이 보내는 버그 해결

기타: 마감시간 변경 코드 리팩토링, 이제 메인공지를 0번째 index로 판단하는게 아니라 id===1인 content를 우선적으로 찾음