### PR TITLE
fix: vercel alias

### DIFF
--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -30,7 +30,7 @@ jobs:
         run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
       - name: Deploy Project Artifacts to Vercel
         id: vercel-deploy
-        run: echo "url=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})" >> $GITHUB_OUTPUT
+        run: echo "url=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} | sed 's/https:\/\///')" >> $GITHUB_OUTPUT
       - name: alias to staging
         run: vercel alias set ${{ steps.vercel-deploy.outputs.url }} stg.ziggle.gistory.me --token=${{ secrets.VERCEL_TOKEN }}
       - name: Update GitHub Deployment Status (success)


### PR DESCRIPTION
vercel alias 명령어를 사용할 때 https:// 스킴이 들어있으면 오류가 납니다
sed 명령어를 사용해서 제거하였습니다

related issue: https://github.com/orgs/vercel/discussions/1826