### PR TITLE
fix: include secret env in build

### DIFF
--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -45,8 +45,8 @@ jobs:
 
       - name: setup environment
         run: |
-          echo "${{ vars.ENV }}" >> .env.local
-          echo "NEXTAUTH_SECRET=${{ secrets.NEXTAUTH_SECRET }}" >> .env.local
+          echo "${{ vars.ENV }}" >> .env.production
+          echo "NEXTAUTH_SECRET=${{ secrets.NEXTAUTH_SECRET }}" >> .env.production
 
       - name: Build, tag, and push image to Amazon ECR
         uses: docker/build-push-action@v2


### PR DESCRIPTION
https://github.com/vercel/next.js/issues/46296

standalone build에서 .env.local 파일이 포함되지 않는 이슈가 있습니다.

현재 별도의 `.env.production` 파일을 사용하고 있지 않기 때문에 `.env.local` 대신 `.env.production`을 사용하고자 합니다.