### PR TITLE
fix: zabo image too long (yutgarak)

### DIFF
--- a/src/app/components/organisms/Zabo/Zabo.tsx
+++ b/src/app/components/organisms/Zabo/Zabo.tsx
@@ -90,7 +90,8 @@ const Zabo = async (props: ZaboProps & PropsWithLng) => {
                   src={url}
                   alt={title}
                   width={200}
-                  height={200}
+                  height={350}
+                  style={{ width: '200px', height: 'auto', maxHeight: '350px' }}
                   className={
                     'rounded-[5px] border border-gray-300 object-cover'
                   }


### PR DESCRIPTION
이미지가 엿가락처럼 긴 문제를 Next Image 컴포넌트에 style을 붙이고 height: auto, maxHeight: 350px를 넣어서 해결했습니다.
보통 16:9 이미지(포스터)를 올리니까 maxHeight: 350px로 잡았습니다만(width가 200px이므로), 디자인팀의 의견에 따라 조정이 필요할듯 합니다.

before:
![image](https://github.com/user-attachments/assets/b425e282-0560-4158-989e-3cad9e4f7fe9)

after:
![image](https://github.com/user-attachments/assets/98495114-579d-4a24-a925-15e344aeadb5)


ref: [stackoverflow](https://stackoverflow.com/questions/65169431/how-to-set-the-next-image-component-to-100-height)