### PR TITLE
fix: unintended early return

### DIFF
--- a/src/app/[lng]/write/NoticeEditor.tsx
+++ b/src/app/[lng]/write/NoticeEditor.tsx
@@ -144,14 +144,15 @@ const NoticeEditor = ({
         type: 'SET_ADDITIONAL_KOREAN_CONTENT',
         additionalKoreanContent: '',
       });
-      if (englishTitle === undefined || englishContent === undefined) return;
-      dispatch({ type: 'SET_ENGLISH_TITLE', englishTitle });
-      dispatch({ type: 'SET_ENGLISH_CONTENT', englishContent });
-      dispatch({
-        type: 'SET_ADDITIONAL_ENGLISH_CONTENT',
-        additionalEnglishContent: '',
-      });
-      dispatch({ type: 'SET_DEADLINE', deadline: dayjs(deadline) });
+      if (englishTitle !== undefined && englishContent !== undefined) {
+        dispatch({ type: 'SET_ENGLISH_TITLE', englishTitle });
+        dispatch({ type: 'SET_ENGLISH_CONTENT', englishContent });
+        dispatch({
+          type: 'SET_ADDITIONAL_ENGLISH_CONTENT',
+          additionalEnglishContent: '',
+        });
+        dispatch({ type: 'SET_DEADLINE', deadline: dayjs(deadline) });
+      }
       setIsLoading(false);
     };
 

--- a/src/app/[lng]/write/NoticeEditor.tsx
+++ b/src/app/[lng]/write/NoticeEditor.tsx
@@ -151,8 +151,10 @@ const NoticeEditor = ({
           type: 'SET_ADDITIONAL_ENGLISH_CONTENT',
           additionalEnglishContent: '',
         });
-        dispatch({ type: 'SET_DEADLINE', deadline: dayjs(deadline) });
       }
+      if (deadline)
+        dispatch({ type: 'SET_DEADLINE', deadline: dayjs(deadline) });
+
       setIsLoading(false);
     };
 


### PR DESCRIPTION
loadExistingNotice 함수에서 return문이 일찍 사용되어, 영어 공지가 없는 공지의 isLoading값이 false로 바뀌지 않아 해당 문제가 발생하였습니다.

early return 대신 해당 코드를 if문 내로 넣어 해결하였습니다.

또한 deadline 처리 로직도 구현되어 있지 않은 것 같아, 해당 부분 추가하였습니다. (새 파일 기준 line 155-156)
혹시 다른 부분에서 구현되진 않았나 더블체크한 후 수정하였지만, 리뷰어께서도 이 부분 한번 더 확인 부탁드려요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **기능 개선**
	- 기존 공지사항 로드 및 영어 콘텐츠 유무에 따른 액션 디스패치 로직을 개선하여 가독성을 높임.
	- 공지사항 및 초안 로딩 프로세스를 간소화하여 상태 설정을 보다 조직적으로 관리.
	- 마감일 처리 로직을 조정하여 정의된 경우에만 디스패치되도록 함.
  
- **문서화**
	- `NoticeEditorProps` 인터페이스 업데이트, 명확성을 위한 컨텍스트 제공.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->