### PR TITLE
fix: loaded draft setting logic

### DIFF
--- a/src/app/[lng]/write/NoticeEditor.tsx
+++ b/src/app/[lng]/write/NoticeEditor.tsx
@@ -109,20 +109,33 @@ const NoticeEditor = ({
         return;
       }
 
-      dispatch({ type: 'SET_KOREAN_TITLE', koreanTitle: draft.korean.title });
+      const { korean, english, deadline } = draft;
+      dispatch({ type: 'SET_KOREAN_TITLE', koreanTitle: korean.title });
       dispatch({
         type: 'SET_KOREAN_CONTENT',
-        koreanContent: draft.korean.content,
+        koreanContent: korean.content,
       });
-      if (!draft.english) return;
-      dispatch({
-        type: 'SET_ENGLISH_TITLE',
-        englishTitle: draft.english.title,
-      });
-      dispatch({
-        type: 'SET_ENGLISH_CONTENT',
-        englishContent: draft.english.content,
-      });
+      if (english) {
+        dispatch({
+          type: 'TOGGLE_ENGLISH_VERSION',
+        });
+        dispatch({
+          type: 'SET_ENGLISH_TITLE',
+          englishTitle: english.title,
+        });
+        dispatch({
+          type: 'SET_ENGLISH_CONTENT',
+          englishContent: english.content,
+        });
+        if (english.additionalContent) {
+          dispatch({
+            type: 'SET_ADDITIONAL_ENGLISH_CONTENT',
+            additionalEnglishContent: english.additionalContent,
+          });
+        }
+      }
+      if (deadline)
+        dispatch({ type: 'SET_DEADLINE', deadline: dayjs(deadline) });
 
       setIsLoading(false);
     };


### PR DESCRIPTION
영어공지 데이터를 추가하려면 reducer에서 `TOGGLE_ENGLISH_VERSION` 실행이 필요했었습니다. 이를 추가했습니다.

[PR 390](https://github.com/gsainfoteam/ziggle-fe/pull/390)과 유사한 문제도 있길래 함께 해결했습니다.
잘못 사용된 early return을 없앴고, 영어공지 로딩 로직을 수정했으며, deadline 로딩 로직을 추가했습니다.

개인적인 의견으로, editorStateReducer의 구조에 문제가 있습니다. 영어공지 draft 로딩이 필요할 경우 `TOGGLE_ENGLISH_VERSION` 실행 후에야 내용을 변경할 수 있는데, state.english 값을 곧바로 수정 가능한 action을 만들어 사용하는게 코드 가독성 면에서 좋아보입니다. 비슷한 코드를 다른 곳(공지 수정 로직)에서 또 사용해야 하기도 하구요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 초안 공지사항 처리 및 기존 공지사항 로딩 기능 개선.
	- 영어 콘텐츠에 대한 추가 콘텐츠 존재 여부 확인 기능 추가.

- **버그 수정**
	- 공지사항 로딩 로직 개선으로 상태 관리 최적화.
	- 빈 문자열이 있을 경우에도 한국어 및 영어 버전의 추가 콘텐츠를 일관되게 처리.

- **문서화**
	- `NoticeEditorProps` 인터페이스 업데이트로 공지사항 속성 구조 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->