### PR TITLE
:bug: Fix empty addi-notice generated when modify

### DIFF
--- a/src/app/[lng]/write/EditableTimer.tsx
+++ b/src/app/[lng]/write/EditableTimer.tsx
@@ -27,9 +27,9 @@ const EditableTimer = ({
     }, 1000);
 
     return () => clearInterval(interval);
-  }, []);
+  }, [createdAt]);
 
-  const isEditable = timeRemaining.minutes > 0 && timeRemaining.seconds > 0;
+  const isEditable = timeRemaining.minutes > 0 && timeRemaining.seconds >= 0;
 
   return (
     <p
@@ -45,7 +45,10 @@ const EditableTimer = ({
         <>
           {t('write.editableTimer')}{' '}
           <span className={'font-bold'}>
-            {`${timeRemaining.minutes}:${timeRemaining.seconds}`}
+            {`${timeRemaining.minutes}:${String(timeRemaining.seconds).padStart(
+              2,
+              '0',
+            )}`}
           </span>
         </>
       ) : (

--- a/src/app/[lng]/write/NoticeEditor.tsx
+++ b/src/app/[lng]/write/NoticeEditor.tsx
@@ -323,7 +323,7 @@ const NoticeEditor = ({
       }
     }
 
-    const isAdditionalAttached = state.korean.additionalContent !== undefined;
+    const isAdditionalAttached = !!state.korean.additionalContent;
 
     if (isAdditionalAttached) {
       const additionalKoreanNotice = await createAdditionalNotice({


### PR DESCRIPTION
공지 수정 시 추가 공지가 작성되는 버그를 해결했습니다.
추가공지 내용이 없는 것을 판별할 때 `content !== undefined`를 사용했으나, empty string !== undefined가 true라는 문제가 있었습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 타이머의 남은 시간 계산이 `createdAt` 변경 시 자동으로 업데이트됩니다.
	- 타이머가 0초에 도달해도 편집 가능 상태를 유지하도록 조정되었습니다.
	- 타이머의 초 표시 형식이 개선되어 10초 미만일 때 앞에 0이 추가됩니다.

- **버그 수정**
	- `NoticeEditor`의 추가 콘텐츠 체크 로직이 간소화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->