### PR TITLE
✨ Add group selector and bussiness logic

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,5 +18,10 @@
     "Zabo",
     "Ziggle"
   ],
-  "svg.preview.background": "custom"
+  "svg.preview.background": "custom",
+  "i18n-ally.localesPaths": [
+    "public/tinymce/langs",
+    "src/app/i18next/locales",
+    "public/tinymce/plugins/help/js/i18n"
+  ]
 }

--- a/src/api/notice/notice.ts
+++ b/src/api/notice/notice.ts
@@ -105,6 +105,7 @@ export const createNotice = ({
   images,
   tags,
   category,
+  groupId,
 }: {
   title: string;
   deadline?: Date;
@@ -112,9 +113,18 @@ export const createNotice = ({
   images: string[];
   tags: number[];
   category: (typeof Category)[keyof typeof Category];
+  groupId: string | null;
 }): Promise<NoticeDetail> =>
   ziggleApi
-    .post('/notice', { title, deadline, body, images, tags, category })
+    .post('/notice', {
+      title,
+      deadline,
+      body,
+      images,
+      tags,
+      category,
+      groupId: groupId ?? undefined,
+    })
     .then((res) => res.data);
 
 export const updateNotice = ({

--- a/src/app/[lng]/write/NoticeEditor.tsx
+++ b/src/app/[lng]/write/NoticeEditor.tsx
@@ -676,8 +676,6 @@ const NoticeEditor = ({
             }
             t={t}
           />
-
-          {state.account}
         </>
       )}
 

--- a/src/app/[lng]/write/NoticeEditor.tsx
+++ b/src/app/[lng]/write/NoticeEditor.tsx
@@ -30,6 +30,7 @@ import { PropsWithLng, T } from '@/app/i18next';
 import { useTranslation } from '@/app/i18next/client';
 import AddPhotoIcon from '@/assets/icons/add-photo.svg';
 import ClockIcon from '@/assets/icons/clock.svg';
+import ColorFilterIcon from '@/assets/icons/color-filter.svg';
 import GlobeIcon from '@/assets/icons/globe.svg';
 import TagIcon from '@/assets/icons/tag.svg';
 import TypeIcon from '@/assets/icons/type.svg';
@@ -49,6 +50,7 @@ import {
   retrieveDraftFromLocalStorage,
 } from './noticeEditorActions';
 import NoticeTypeSelector from './NoticeTypeSelector';
+import SelectAccountArea from './SelectAccountArea';
 import TagInput, { Tag } from './TagInput';
 import TitleAndContent from './TitleAndContent';
 
@@ -224,6 +226,7 @@ const NoticeEditor = ({
       tags: [...state.tags.map(({ name }) => name)],
       images: state.photos.map(({ file }) => file),
       category: NoticeTypeCatgoryMapper[state.noticeType],
+      groupId: state.account,
       t,
     };
 
@@ -660,6 +663,21 @@ const NoticeEditor = ({
               dispatch({ type: 'SET_PHOTOS', photos })
             }
           />
+
+          <div className="mb-1 mt-10 flex items-center gap-2">
+            <ColorFilterIcon className="w-5 stroke-text md:w-6" />
+            <p className="font-medium md:text-lg">{t('write.selectAccount')}</p>
+          </div>
+
+          <SelectAccountArea
+            account={state.account}
+            setAccount={(account: string | null) =>
+              dispatch({ type: 'SET_ACCOUNT', account })
+            }
+            t={t}
+          />
+
+          {state.account}
         </>
       )}
 

--- a/src/app/[lng]/write/SelectAccountArea.tsx
+++ b/src/app/[lng]/write/SelectAccountArea.tsx
@@ -1,0 +1,53 @@
+import { PropsWithT } from '@/app/i18next';
+import NavArrowRightIcon from '@/assets/icons/nav-arrow-right.svg';
+
+import { EditorAction } from './noticeEditorActions';
+
+interface SelectAccountAreaProps {
+  account: string | null;
+  setAccount: (account: string | null) => void;
+}
+
+// 임시 데이터
+const DUMMY_ACCOUNTS = [
+  { id: 'club_account', name: '동아리 계정' },
+  { id: 'department_account', name: '학과 계정' },
+  { id: 'council_account', name: '학생회 계정' },
+];
+
+const SelectAccountArea = ({
+  account,
+  setAccount,
+  t,
+}: PropsWithT<SelectAccountAreaProps>) => {
+  const handleAccountChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const selectedValue = e.target.value;
+    setAccount(selectedValue === '' ? null : selectedValue);
+  };
+
+  return (
+    <div className="relative mt-2">
+      <div className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2">
+        <NavArrowRightIcon className="w-5 rotate-90 stroke-text" />
+      </div>
+
+      <select
+        value={account ?? ''}
+        onChange={handleAccountChange}
+        className={`w-full appearance-none rounded-[10px] bg-greyLight px-4 py-3.5 ${
+          account ? 'text-primary' : 'text-greyDark'
+        } focus:border-primary focus:outline-none`}
+      >
+        <option value="">{t('write.writeAsMyself')}</option>
+
+        {DUMMY_ACCOUNTS.map((acc) => (
+          <option key={acc.id} value={acc.id}>
+            {acc.name}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+};
+
+export default SelectAccountArea;

--- a/src/app/[lng]/write/handle-notice-submit.ts
+++ b/src/app/[lng]/write/handle-notice-submit.ts
@@ -22,6 +22,7 @@ export interface NoticeSubmitForm {
   tags: string[];
   images: File[];
   category: (typeof Category)[keyof typeof Category];
+  groupId: string | null;
 }
 
 export const TITLE_MAX_LENGTH = 50;
@@ -37,6 +38,7 @@ const handleNoticeSubmit = async ({
   tags,
   images,
   category,
+  groupId,
   t,
 }: NoticeSubmitForm & { t: T }) => {
   const warningSwal = WarningSwal(t);
@@ -200,6 +202,7 @@ const handleNoticeSubmit = async ({
     images: imageKeys,
     tags: tagIds,
     category,
+    groupId,
   }).catch(() => null);
 
   if (!notice) {

--- a/src/app/[lng]/write/noticeEditorActions.ts
+++ b/src/app/[lng]/write/noticeEditorActions.ts
@@ -22,6 +22,7 @@ export interface EditorState {
   tags: Tag[];
   photos: FileWithUrl[];
   isLoading: boolean;
+  account: string | null;
 }
 
 export const initialEditorState: EditorState = {
@@ -37,6 +38,7 @@ export const initialEditorState: EditorState = {
   tags: [],
   photos: [],
   isLoading: false,
+  account: null,
 };
 
 export type EditorAction =
@@ -55,7 +57,8 @@ export type EditorAction =
   | {
       type: 'SET_ADDITIONAL_ENGLISH_CONTENT';
       additionalEnglishContent: string;
-    };
+    }
+  | { type: 'SET_ACCOUNT'; account: string | null };
 
 export const editorStateReducer = (
   state: EditorState,
@@ -151,6 +154,8 @@ export const editorStateReducer = (
         },
       };
     }
+    case 'SET_ACCOUNT':
+      return { ...state, account: action.account };
     default:
       return state;
   }

--- a/src/app/i18next/locales/en/translation.json
+++ b/src/app/i18next/locales/en/translation.json
@@ -299,6 +299,7 @@
     "photoDescription": "The first of the attached photos is set as the representative photo.",
     "dragToAddPhoto": "Drag to add photos",
     "orAddFromPC": "...or browse files",
+    "selectAccount": "Select Account",
 
     "submit": "Submit Notice",
     "submitDescription": "You can edit your notice in 15 mins. \n Please double-check your content before submitting.",
@@ -348,7 +349,8 @@
       "sendingAlarmNotice":"Sending notifications...", 
       "sendPushNoticeFail": "Failed to send push notification",
       "sendPushNoticeSuccess": "Push notification sent successfully"
-    }
+    },
+    "writeAsMyself": "Write as myself"
   },
   "group": {
     "mainTitle": "My Groups",

--- a/src/app/i18next/locales/ko/translation.json
+++ b/src/app/i18next/locales/ko/translation.json
@@ -288,6 +288,7 @@
     "photoDescription": "첨부된 사진 중 첫 번째 사진이 대표 사진으로 설정됩니다.",
     "dragToAddPhoto": "끌어서 사진 추가",
     "orAddFromPC": "...또는 파일 선택",
+    "selectAccount": "계정 선택",
 
     "submit": "공지 제출하기",
     "submitDescription": "공지 제출 시 15분 내로 수정이 가능합니다.\n 제출 전에 내용을 다시 한 번 확인해주세요.",
@@ -336,7 +337,8 @@
       "sendingAlarmNotice":"알림 보내는 중...", 
       "sendPushNoticeFail": "알림 전송에 실패했습니다",
       "sendPushNoticeSuccess": "알림을 성공적으로 보냈습니다"
-    }
+    },
+    "writeAsMyself": "내 계정으로 작성"
   },
   "group": {
     "mainTitle": "내가 속한 그룹들",


### PR DESCRIPTION
![Google Chrome 2025-02-05 23 57 39](https://github.com/user-attachments/assets/3ba55c11-f1a2-443d-ae42-64d24bac0b95)
![Google Chrome 2025-02-05 23 57 41](https://github.com/user-attachments/assets/ded905cf-c2d5-47d0-8f57-2e789f1ae1ab)


공지 작성 시 작성 명의 계정을 선택하는 UI입니다.
아직 그룹 리스트 받아오는 API가 없기에 UI와 비즈니스 로직만 만들었습니다.
그룹 리스트 받는 api가 나오는대로 후속 pr에서 처리하겠습니다.

UI는 options 부분이 figma와 다릅니다. 현재 제 시간관계상 UI를 디자인대로 구현할 수 없었습니다. 후속 이슈를 만들어두겠습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
	- 공지사항 작성 시 계정 선택 옵션이 추가되어, 사용자가 본인 또는 다른 계정으로 게시글을 작성할 수 있습니다.
	- 드롭다운 메뉴와 직관적인 레이블("계정 선택", "내 계정으로 작성")이 적용되어 인터페이스가 개선되었습니다.
	- 다국어 지원을 위한 번역 파일이 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->