### PR TITLE
refactor: reorder Zabo component structure

### DIFF
--- a/src/app/components/shared/Zabo/Zabo.tsx
+++ b/src/app/components/shared/Zabo/Zabo.tsx
@@ -91,17 +91,9 @@ const Zabo = async (props: ZaboProps & PropsWithLng) => {
           {title}
         </p>
 
-        {!hasImage && <ZaboTags notice={props} />}
-
         {hasImage && <ZaboImageCarousel imageUrls={imageUrls} title={title} />}
 
-        {hasImage && (
-          <div className="mx-2 my-4">
-            <ZaboActions {...props} />
-          </div>
-        )}
-
-        {hasImage && <ZaboTags notice={props} />}
+        <ZaboTags notice={props} />
 
         <div
           className={'mx-4 mt-[10px] line-clamp-3 text-lg dark:text-dark_white'}
@@ -109,11 +101,9 @@ const Zabo = async (props: ZaboProps & PropsWithLng) => {
           {props.content}
         </div>
 
-        {!hasImage && (
-          <div className="mx-2 mt-4">
-            <ZaboActions {...props} />
-          </div>
-        )}
+        <div className="mx-2 mt-4">
+          <ZaboActions {...props} />
+        </div>
       </div>
     </Link>
   );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Zabo 카드에서 태그와 액션 버튼이 항상 동일한 위치와 스타일로 표시되도록 렌더링 방식을 단순화했습니다.  
  * 이미지가 있을 때와 없을 때의 태그 및 액션 버튼의 표시 위치가 일관되게 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->