### PR TITLE
feat: change toast position and design

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "react-responsive": "^9.0.2",
     "react-responsive-masonry": "^2.1.7",
     "server-only": "^0.0.1",
+    "sonner": "^2.0.7",
     "sweetalert2": "^11.7.31",
     "swr": "^2.2.5",
     "tinymce": "^6.8.3"

--- a/src/api/group/search-groups-with-name.ts
+++ b/src/api/group/search-groups-with-name.ts
@@ -5,8 +5,8 @@ import { GroupInfo } from './group';
 
 export const searchGroupWithName = async (groupName: string, lang: Locale) => {
   return await ziggleApi
-    .get<{ list: GroupInfo[] }>(
-      `/group/search?query=${encodeURIComponent(groupName)}&lang=${lang}`,
-    )
+    .get<{
+      list: GroupInfo[];
+    }>(`/group/search?query=${encodeURIComponent(groupName)}&lang=${lang}`)
     .then(({ data: { list } }) => list);
 };

--- a/src/app/[lng]/(with-page-layout)/(with-sidebar-layout)/notice/[id]/Actions.tsx
+++ b/src/app/[lng]/(with-page-layout)/(with-sidebar-layout)/notice/[id]/Actions.tsx
@@ -2,8 +2,8 @@
 
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
-import { toast } from 'react-hot-toast';
 import { Trans } from 'react-i18next';
+import { toast } from 'sonner';
 import Swal from 'sweetalert2';
 
 import LogEvents from '@/api/log/log-events';

--- a/src/app/[lng]/(with-page-layout)/(with-sidebar-layout)/notice/[id]/SendPushNotificationAlert.tsx
+++ b/src/app/[lng]/(with-page-layout)/(with-sidebar-layout)/notice/[id]/SendPushNotificationAlert.tsx
@@ -94,7 +94,7 @@ const SendPushAlarm = ({
 
     const intervalDuration = getIntervalDuration(
       timeRemaining.minutes,
-      timeRemaining.seconds
+      timeRemaining.seconds,
     );
 
     const interval = setInterval(() => {

--- a/src/app/[lng]/(with-page-layout)/(with-sidebar-layout)/notice/[id]/getTimeDiff.ts
+++ b/src/app/[lng]/(with-page-layout)/(with-sidebar-layout)/notice/[id]/getTimeDiff.ts
@@ -2,7 +2,7 @@ import dayjs, { Dayjs } from 'dayjs';
 
 export const isServer = typeof window === 'undefined';
 
-const CLIENT_SERVER_TIME_OFFSET_SECONDS = 10
+const CLIENT_SERVER_TIME_OFFSET_SECONDS = 10;
 export const getTimeDiff = (createdAt: Dayjs | string) => {
   const currentTime = dayjs();
   const diffInSeconds = dayjs(createdAt)

--- a/src/app/[lng]/layout.tsx
+++ b/src/app/[lng]/layout.tsx
@@ -7,7 +7,6 @@ import { dir } from 'i18next';
 import type { Metadata } from 'next';
 import localFont from 'next/font/local';
 import Script from 'next/script';
-import { Toaster } from 'react-hot-toast';
 
 import { createTranslation, PropsWithLng } from '@/app/i18next';
 import { languages } from '@/app/i18next/settings';
@@ -116,10 +115,7 @@ export default async function RootLayout({
           'selection:bg-primary/20'
         }
       >
-        <AmplitudeProvider>
-          {children}
-          <Toaster position="bottom-right" />
-        </AmplitudeProvider>
+        <AmplitudeProvider>{children}</AmplitudeProvider>
       </body>
       {process.env.NEXT_PUBLIC_GA_TRACKING_ID && (
         <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_TRACKING_ID} />

--- a/src/app/[lng]/layout.tsx
+++ b/src/app/[lng]/layout.tsx
@@ -118,7 +118,7 @@ export default async function RootLayout({
       >
         <AmplitudeProvider>
           {children}
-          <Toaster />
+          <Toaster position="bottom-right" />
         </AmplitudeProvider>
       </body>
       {process.env.NEXT_PUBLIC_GA_TRACKING_ID && (

--- a/src/app/[lng]/write/NoticeEditor.tsx
+++ b/src/app/[lng]/write/NoticeEditor.tsx
@@ -7,7 +7,7 @@ import 'react-datetime-picker/dist/DateTimePicker.css';
 import dayjs, { Dayjs } from 'dayjs';
 import { useRouter } from 'next/navigation';
 import { useEffect, useReducer, useRef, useState } from 'react';
-import { toast } from 'react-hot-toast';
+import { toast } from 'sonner';
 import Swal from 'sweetalert2';
 import { Editor } from 'tinymce';
 
@@ -217,7 +217,7 @@ const NoticeEditor = ({
     const noticeToSubmit: NoticeSubmitForm & { t: T } = {
       title: state.korean.title,
       deadline: state.deadline
-        ? state.deadline.toDate() ?? undefined
+        ? (state.deadline.toDate() ?? undefined)
         : undefined,
       noticeLanguage: state.english ? 'both' : 'ko',
       koreanBody: state.korean.content,

--- a/src/app/[lng]/write/handle-notice-submit.ts
+++ b/src/app/[lng]/write/handle-notice-submit.ts
@@ -1,4 +1,4 @@
-import { toast } from 'react-hot-toast';
+import { toast } from 'sonner';
 import Swal from 'sweetalert2';
 
 import { uploadImages } from '@/api/image/image';

--- a/src/app/components/layout/Footer/Footer.stories.tsx
+++ b/src/app/components/layout/Footer/Footer.stories.tsx
@@ -1,6 +1,6 @@
 import { StoryFn } from '@storybook/react';
 
-import { Locale, fallbackLng } from '@/app/i18next/settings';
+import { fallbackLng, Locale } from '@/app/i18next/settings';
 
 import Footer from '.';
 

--- a/src/app/components/layout/InitClient.tsx
+++ b/src/app/components/layout/InitClient.tsx
@@ -12,6 +12,8 @@ import { SWRConfig } from 'swr';
 import { ziggleApi } from '@/api';
 import { PropsWithLng } from '@/app/i18next';
 
+import ThemeToaster from './ThemeToaster';
+
 const InstallApp = dynamic(() => import('./InstallApp'), {
   ssr: false,
 });
@@ -24,23 +26,28 @@ const InitClient = ({
   lng,
   children,
   emptyLayout = false,
-}: React.PropsWithChildren<PropsWithLng & InitClientProps>) => (
-  <SWRConfig
-    value={{ fetcher: (path) => ziggleApi.get(path).then(({ data }) => data) }}
-  >
-    <SessionProvider>
-      <OverlayProvider>
-        {!emptyLayout && (
-          <Suspense>
-            <InstallApp lng={lng} />
-          </Suspense>
-        )}
-        <ThemeProvider enableSystem defaultTheme="system">
-          {children}
-        </ThemeProvider>
-      </OverlayProvider>
-    </SessionProvider>
-  </SWRConfig>
-);
+}: React.PropsWithChildren<PropsWithLng & InitClientProps>) => {
+  return (
+    <SWRConfig
+      value={{
+        fetcher: (path) => ziggleApi.get(path).then(({ data }) => data),
+      }}
+    >
+      <SessionProvider>
+        <OverlayProvider>
+          {!emptyLayout && (
+            <Suspense>
+              <InstallApp lng={lng} />
+            </Suspense>
+          )}
+          <ThemeProvider enableSystem defaultTheme="system">
+            <ThemeToaster />
+            {children}
+          </ThemeProvider>
+        </OverlayProvider>
+      </SessionProvider>
+    </SWRConfig>
+  );
+};
 
 export default InitClient;

--- a/src/app/components/layout/Navbar/Navbar.stories.tsx
+++ b/src/app/components/layout/Navbar/Navbar.stories.tsx
@@ -1,5 +1,5 @@
-import { fallbackLng } from '@/app/i18next/settings';
 import {} from '@/app/i18next/client';
+import { fallbackLng } from '@/app/i18next/settings';
 
 import Navbar from '.';
 

--- a/src/app/components/layout/ThemeToaster.tsx
+++ b/src/app/components/layout/ThemeToaster.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useTheme } from 'next-themes';
+import { Toaster, ToasterProps } from 'sonner';
+
+const ThemeToaster = () => {
+  const { theme } = useTheme();
+
+  return (
+    <Toaster
+      position="bottom-left"
+      theme={theme as ToasterProps['theme']}
+      toastOptions={{
+        classNames: {
+          toast: '!bg-white !border-greyLight',
+        },
+      }}
+    />
+  );
+};
+
+export default ThemeToaster;

--- a/src/app/components/shared/Zabo/ResultZabo/ResultTextZabo.tsx
+++ b/src/app/components/shared/Zabo/ResultZabo/ResultTextZabo.tsx
@@ -70,7 +70,7 @@ const ResultTextZabo = async (props: ResultZaboProps) => {
               {content ?? t('zabo.noContent')}
             </HighlightedText>
           ) : (
-            content ?? t('zabo.noContent')
+            (content ?? t('zabo.noContent'))
           )}
         </div>
         <ZaboActions {...props} />

--- a/src/app/components/shared/Zabo/ZaboActions.tsx
+++ b/src/app/components/shared/Zabo/ZaboActions.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { toast } from 'react-hot-toast';
+import { toast } from 'sonner';
 import Swal from 'sweetalert2';
 
 import LogEvents from '@/api/log/log-events';

--- a/src/app/components/shared/Zabo/ZaboImageCarousel.tsx
+++ b/src/app/components/shared/Zabo/ZaboImageCarousel.tsx
@@ -36,12 +36,13 @@ const ZaboImageCarousel = ({
         Math.floor(e.currentTarget.scrollLeft / (imageSize + gap)) +
         Math.floor(
           (e.currentTarget.clientWidth + gap + imageSize) / (imageSize + gap),
-        ) - 1,
+        ) -
+        1,
     });
   };
 
   return (
-    <div className="flex w-full flex-col items-center gap-2 group">
+    <div className="group flex w-full flex-col items-center gap-2">
       <div
         ref={imagesContainerRef}
         onScroll={handleScroll}
@@ -58,8 +59,8 @@ const ZaboImageCarousel = ({
           <Image
             style={{
               scrollSnapAlign: 'start',
-              minWidth: imageSize, 
-              minHeight: imageSize
+              minWidth: imageSize,
+              minHeight: imageSize,
             }}
             key={url}
             src={url}
@@ -71,19 +72,22 @@ const ZaboImageCarousel = ({
         ))}
       </div>
       {indicesInView.last <= imageUrls.length && (
-        <div className="group-hover:opacity-100 opacity-0 flex h-4 w-fit items-center justify-center rounded-full px-2 py-1 backdrop-blur-lg backdrop-invert-[30%] transition-opacity duration-500">
+        <div className="flex h-4 w-fit items-center justify-center rounded-full px-2 py-1 opacity-0 backdrop-blur-lg backdrop-invert-[30%] transition-opacity duration-500 group-hover:opacity-100">
           {imageUrls.map((url, i) => (
             <div
               key={url}
               className={`
               flex rounded-full bg-dark_white
               ${
-                i < indicesInView.first - 2 || indicesInView.first + maxControls - 1 < i
+                i < indicesInView.first - 2 ||
+                indicesInView.first + maxControls - 1 < i
                   ? 'mx-0 h-0 w-0'
                   : 'mx-1 h-2 w-2' +
-                    (i == indicesInView.first + maxControls - 2 || i == indicesInView.first - 1
+                    (i == indicesInView.first + maxControls - 2 ||
+                    i == indicesInView.first - 1
                       ? ' scale-75'
-                      : i == indicesInView.first + maxControls - 1 || i == indicesInView.first - 2
+                      : i == indicesInView.first + maxControls - 1 ||
+                          i == indicesInView.first - 2
                         ? ' scale-50'
                         : '')
               }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11266,6 +11266,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sonner@npm:^2.0.7":
+  version: 2.0.7
+  resolution: "sonner@npm:2.0.7"
+  peerDependencies:
+    react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+  checksum: 10c0/6966ab5e892ed6aab579a175e4a24f3b48747f0fc21cb68c3e33cb41caa7a0eebeb098c210545395e47a18d585eb8734ae7dd12d2bd18c8a3294a1ee73f997d9
+  languageName: node
+  linkType: hard
+
 "source-map-js@npm:^1.0.1, source-map-js@npm:^1.0.2, source-map-js@npm:^1.2.1":
   version: 1.2.1
   resolution: "source-map-js@npm:1.2.1"
@@ -12951,6 +12961,7 @@ __metadata:
     react-responsive: "npm:^9.0.2"
     react-responsive-masonry: "npm:^2.1.7"
     server-only: "npm:^0.0.1"
+    sonner: "npm:^2.0.7"
     storybook: "npm:^8.1.2"
     sweetalert2: "npm:^11.7.31"
     swr: "npm:^2.2.5"


### PR DESCRIPTION

https://github.com/user-attachments/assets/ded17dc1-ed04-4dd9-bb6f-19007b5311cd

<img width="40%" alt="CleanShot 2025-09-04 at 20 34 25@2x" src="https://github.com/user-attachments/assets/3071880d-ef6e-4fb4-8383-c6b7e70832d3" />  

** 모바일 웹 환경에서는 좌우 전체를 덮습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 앱 전반의 알림(toast) 시스템을 Sonner로 전환해 테마와 연동되고 화면 좌하단에 일관된 스타일로 표시됩니다. 공지 보기/작성, 액션 수행 등 알림을 사용하는 화면에서 동일하게 적용됩니다.
- 유지보수
  - 런타임 의존성에 Sonner가 추가되었습니다.
- 리팩터링/스타일
  - 불필요한 기존 Toaster 제거 및 경미한 UI/코드 서식 정리(동작 변화 없음).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->