### PR TITLE
[feat] get group contain me

### DIFF
--- a/.env
+++ b/.env
@@ -3,5 +3,5 @@ NEXT_PUBLIC_IDP_BASE_URL=https://idp.gistory.me/
 NEXT_PUBLIC_IDP_CLIENT_ID=b0c3a25f-1291-410c-bac3-192094d47c77
 NEXT_PUBLIC_IDP_REDIRECT_URI=http://localhost:3000/api/login
 NEXTAUTH_URL=http://localhost:3000
-NEXT_PUBLIC_GROUPS_API_URL=https://stg.groups.gistory.me/
+NEXT_PUBLIC_GROUPS_API_URL=https://api.stg.groups.gistory.me/
 NEXT_PUBLIC_GROUPS_URL=https://groups.gistory.me

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,7 +12,8 @@
     "source.sortImports": "never",
     "source.organizeImports": "never"
   },
-  "editor.formatOnSave": false,
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
   "cSpell.words": [
     "Swal",
     "Zabo",

--- a/src/api/group/group.ts
+++ b/src/api/group/group.ts
@@ -2,7 +2,6 @@ import axios from 'axios';
 import dayjs from 'dayjs';
 
 import { ziggleApi } from '..';
-import { auth } from '../auth/auth';
 
 export interface GroupInfo {
   uuid: string;
@@ -21,32 +20,23 @@ export interface InviteCode {
   code: string;
 }
 
-export const getGroupsToken = async (): Promise<string> => {
-  const session = await auth();
-  const idpToekn = session?.accessToken;
-  const { groupsToken } = await axios
-    .post<{ groupsToken: string }>(
-      `${process.env.NEXT_PUBLIC_GROUPS_API_URL}/external`,
-      {
-        idpToekn: idpToekn,
-      },
-    )
-    .then(({ data }) => data);
-
-  return groupsToken;
+const groupsBaseUrl = process.env.NEXT_PUBLIC_GROUPS_API_URL;
+const clientId = process.env.GROUPS_CLIENT_ID;
+const clientSecret = process.env.GROUPS_CLIENT_SECRET;
+const basedURL = process.env.GROUPS_REDIRECT_BASE_URI;
+export const thirdPartyAuth = async (path: string) => {
+  const { data } = await axios.get(
+    `${groupsBaseUrl}/third-party/auth?client_id=${clientId}&redirect_url=${basedURL}${path}`,
+  );
 };
 
-export const getMyGroups = async (): Promise<GroupInfo[]> => {
-  const groupsToken = await getGroupsToken();
-
-  return ziggleApi
-    .get<GroupInfo[]>('/group/my', {
-      headers: {
-        'Groups-Token': groupsToken,
-      },
-    })
-    .then(({ data }) => data);
+export const getGroupsToken = async () => {
+  return;
 };
+
+export const getMyGroups = async () => {
+  return;
+}
 
 export const getGroup = async (uuid: string): Promise<GroupInfo> => {
   return ziggleApi.get<GroupInfo>(`/group/${uuid}`).then(({ data }) => data);

--- a/src/api/group/group.ts
+++ b/src/api/group/group.ts
@@ -1,6 +1,8 @@
+import axios from 'axios';
 import dayjs from 'dayjs';
 
 import { ziggleApi } from '..';
+import { auth } from '../auth/auth';
 
 export interface GroupInfo {
   uuid: string;
@@ -20,8 +22,15 @@ export interface InviteCode {
 }
 
 export const getGroupsToken = async (): Promise<string> => {
-  const { groupsToken } = await ziggleApi
-    .post<{ groupsToken: string }>('/group/token')
+  const session = await auth();
+  const idpToekn = session?.accessToken;
+  const { groupsToken } = await axios
+    .post<{ groupsToken: string }>(
+      `${process.env.NEXT_PUBLIC_GROUPS_API_URL}/external`,
+      {
+        idpToekn: idpToekn,
+      },
+    )
     .then(({ data }) => data);
 
   return groupsToken;

--- a/src/api/group/group.ts
+++ b/src/api/group/group.ts
@@ -39,11 +39,22 @@ export const getGroupsToken = async (code: string) => {
       redirect_uri: redirectUri,
     })
     .then((res) => res.data)
-    .catch((err) => console.error(err));
+    .catch((err) => {
+      console.error(err)
+    });
 };
 
-export const getMyGroups = async () => {
-  return;
+export const getMyGroups = async (accessToken: string) => {
+  return axios
+    .get(`${groupsAPIUrl}third-party/userinfo`, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      }
+    })
+    .then((res) => res.data)
+    .catch((err) => {
+      console.error(err);
+    });
 };
 
 export const getGroup = async (uuid: string): Promise<GroupInfo> => {

--- a/src/api/group/group.ts
+++ b/src/api/group/group.ts
@@ -21,22 +21,25 @@ export interface InviteCode {
 }
 
 const groupsBaseUrl = process.env.NEXT_PUBLIC_GROUPS_API_URL;
-const clientId = process.env.GROUPS_CLIENT_ID;
+const clientId = process.env.NEXT_PUBLIC_GROUPS_CLIENT_ID;
 const clientSecret = process.env.GROUPS_CLIENT_SECRET;
-const basedURL = process.env.GROUPS_REDIRECT_BASE_URI;
+const basedURL = process.env.NEXT_PUBLIC_GROUPS_REDIRECT_BASE_URL;
 export const thirdPartyAuth = async (path: string) => {
   const { data } = await axios.get(
-    `${groupsBaseUrl}/third-party/auth?client_id=${clientId}&redirect_url=${basedURL}${path}`,
+    `${groupsBaseUrl}third-party/authorize?client_id=${clientId}&redirect_uri=${basedURL}${path}`,
   );
 };
 
-export const getGroupsToken = async () => {
+export const getGroupsToken = async (code: string, path: string) => {
+  const { data } = await axios.get(
+    `${groupsBaseUrl}third-party/token/authorize?client_id=${clientId}&code=${code}&redirect_uri=${basedURL}${path}&`,
+  );
   return;
 };
 
 export const getMyGroups = async () => {
   return;
-}
+};
 
 export const getGroup = async (uuid: string): Promise<GroupInfo> => {
   return ziggleApi.get<GroupInfo>(`/group/${uuid}`).then(({ data }) => data);

--- a/src/api/group/group.ts
+++ b/src/api/group/group.ts
@@ -38,7 +38,7 @@ export const getGroupsToken = async (code: string) => {
       code: code,
       redirect_uri: redirectUri,
     })
-    .then((res) => res)
+    .then((res) => res.data)
     .catch((err) => console.error(err));
 };
 

--- a/src/api/notice/notice.ts
+++ b/src/api/notice/notice.ts
@@ -52,7 +52,11 @@ export interface Notice {
   documentUrls: string[];
   isReminded: boolean;
   reactions: Reaction[];
-  groupId: string | null;
+  group: {
+    id: string;
+    name: string;
+    profileImageUrl: string | null;
+  } | null;
 }
 
 export interface Reaction {

--- a/src/api/notice/notice.ts
+++ b/src/api/notice/notice.ts
@@ -111,7 +111,7 @@ export const createNotice = async ({
   images,
   tags,
   category,
-  groupId,
+  group,
 }: {
   title: string;
   deadline?: Date;
@@ -119,13 +119,9 @@ export const createNotice = async ({
   images: string[];
   tags: number[];
   category: (typeof Category)[keyof typeof Category];
-  groupId: string | null;
+  group: { uuid: string; name: string; profileImageUrl: string | null } | null;
 }): Promise<NoticeDetail> => {
   let groupsToken: string | null = null;
-
-  if (groupId) {
-    groupsToken = await getGroupsToken();
-  }
 
   return ziggleApi
     .post(
@@ -137,7 +133,7 @@ export const createNotice = async ({
         images,
         tags,
         category,
-        groupId: groupId ?? undefined,
+        group: group ?? undefined,
       },
       {
         ...(groupsToken

--- a/src/api/notice/notice.ts
+++ b/src/api/notice/notice.ts
@@ -121,8 +121,7 @@ export const createNotice = async ({
   category: (typeof Category)[keyof typeof Category];
   group: { uuid: string; name: string; profileImageUrl: string | null } | null;
 }): Promise<NoticeDetail> => {
-  let groupsToken: string | null = null;
-
+  const groupsToken: string | null = localStorage.getItem('groupsAccessToken');
   return ziggleApi
     .post(
       '/notice',

--- a/src/app/[lng]/page.tsx
+++ b/src/app/[lng]/page.tsx
@@ -1,11 +1,12 @@
-import { redirect } from 'next/navigation';
-
 import { PropsWithLng } from '@/app/i18next';
+import ThirdParty from './thirdParty';
 
-export default async function Home({
-  params: { lng },
-}: {
+type Props = {
   params: PropsWithLng;
-}) {
-  redirect(`/${lng}/home`);
+  searchParams: { [key: string]: string | string[] | undefined };
+};
+
+export default async function Home({ params: { lng }, searchParams }: Props) {
+  const code = searchParams.code;
+  return <ThirdParty code={code as string} lng={lng} />;
 }

--- a/src/app/[lng]/thirdParty.tsx
+++ b/src/app/[lng]/thirdParty.tsx
@@ -1,0 +1,16 @@
+'use client';
+import { redirect } from 'next/navigation';
+type Props = {
+  lng: 'ko' | 'en';
+  code: string;
+};
+export default function ThirdParty({ code, lng }: Props) {
+  if (code && typeof code === 'string') {
+    localStorage.setItem('thirdPartycode', code);
+    const path = localStorage.getItem('redirectPath');
+    redirect(path ? path : `/${lng}/home`);
+  } else {
+    redirect(`/${lng}/home`);
+  }
+  return <div></div>;
+}

--- a/src/app/[lng]/write/NoticeEditor.tsx
+++ b/src/app/[lng]/write/NoticeEditor.tsx
@@ -226,7 +226,7 @@ const NoticeEditor = ({
       tags: [...state.tags.map(({ name }) => name)],
       images: state.photos.map(({ file }) => file),
       category: NoticeTypeCatgoryMapper[state.noticeType],
-      groupId: state.account,
+      group: state.group,
       t,
     };
 
@@ -670,10 +670,14 @@ const NoticeEditor = ({
           </div>
 
           <SelectAccountArea
-            account={state.account}
-            setAccount={(account: string | null) =>
-              dispatch({ type: 'SET_ACCOUNT', account })
-            }
+            group={state.group}
+            setGroup={(
+              group: {
+                uuid: string;
+                name: string;
+                profileImageUrl: string | null;
+              } | null,
+            ) => dispatch({ type: 'SET_ACCOUNT', group })}
             t={t}
           />
         </>

--- a/src/app/[lng]/write/SelectAccountArea.tsx
+++ b/src/app/[lng]/write/SelectAccountArea.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { usePathname } from 'next/navigation';
-import Swal from 'sweetalert2';
 import { use, useEffect, useState } from 'react';
+import Swal from 'sweetalert2';
 
 import {
   getGroupsToken,
@@ -10,10 +10,9 @@ import {
   GroupInfo,
   thirdPartyAuth,
 } from '@/api/group/group';
+import Button from '@/app/components/shared/Button';
 import { PropsWithT } from '@/app/i18next';
 import NavArrowRightIcon from '@/assets/icons/nav-arrow-right.svg';
-
-import { EditorAction } from './noticeEditorActions';
 
 interface SelectAccountAreaProps {
   account: string | null;
@@ -28,19 +27,15 @@ const SelectAccountArea = ({
   const [myGroups, setMyGroups] = useState<GroupInfo[]>([]);
   const [isModalOpen, setIsModalOpen] = useState<Boolean>(false);
   const path: string = usePathname();
-
-  // useEffect(() => {
-  //   thirdPartyAuth(path);
-  //   //TODO: Make Login Hub page for get authrization code
-  //   getGroupsToken('temporary code');
-  // }, [path]);
+  localStorage.setItem('redirectPath', path);
 
   const handleAccountChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const selectedValue = e.target.value;
     setAccount(selectedValue === '' ? null : selectedValue);
-    if (selectedValue === 'groupSelect') {
-      setIsModalOpen(true);
-    }
+  };
+
+  const handleGroupLogin = () => {
+    setIsModalOpen(true);
   };
 
   useEffect(() => {
@@ -53,10 +48,23 @@ const SelectAccountArea = ({
       }).then((result) => {
         if (result.isConfirmed) {
           thirdPartyAuth(path);
+          setIsModalOpen(false);
         }
         setIsModalOpen(false);
       });
   }, [path, isModalOpen]);
+
+  const thirdPartycode = localStorage.getItem('thirdPartycode');
+  useEffect(() => {
+    const handleThirdPartyCode = async () => {
+      if (thirdPartycode) {
+        const data = await getGroupsToken(thirdPartycode);
+        localStorage.removeItem('thirdPartycode');
+        console.log(data.token);
+      }
+      handleThirdPartyCode();
+    };
+  }, [thirdPartycode]);
 
   return (
     <div className="relative mt-2">
@@ -72,14 +80,23 @@ const SelectAccountArea = ({
         } focus:border-primary focus:outline-none`}
       >
         <option value="">{t('write.writeAsMyself')}</option>
-        <option value="groupSelect">If you want write as a group</option>
-
-        {myGroups.map((group) => (
-          <option key={group.uuid} value={group.uuid}>
-            {group.name}
-          </option>
-        ))}
+        {myGroups.length &&
+          myGroups.map((group) => (
+            <option key={group.uuid} value={group.uuid}>
+              {group.name}
+            </option>
+          ))}
       </select>
+
+      <Button
+        variant="contained"
+        className="w-30 my-4 rounded-[10px] py-2"
+        onClick={handleGroupLogin}
+      >
+        <p className="mx-3 my-1 text-base font-bold">
+          Clike here if you want to write as group
+        </p>
+      </Button>
     </div>
   );
 };

--- a/src/app/[lng]/write/SelectAccountArea.tsx
+++ b/src/app/[lng]/write/SelectAccountArea.tsx
@@ -14,14 +14,20 @@ import Button from '@/app/components/shared/Button';
 import { PropsWithT } from '@/app/i18next';
 import NavArrowRightIcon from '@/assets/icons/nav-arrow-right.svg';
 
+type Group = {
+  uuid: string;
+  name: string;
+  profileImageUrl: string | null;
+};
+
 interface SelectAccountAreaProps {
-  account: string | null;
-  setAccount: (account: string | null) => void;
+  group: Group | null;
+  setGroup: (group: Group | null) => void;
 }
 
 const SelectAccountArea = ({
-  account,
-  setAccount,
+  group,
+  setGroup,
   t,
 }: PropsWithT<SelectAccountAreaProps>) => {
   const [myGroups, setMyGroups] = useState<GroupInfo[]>([]);
@@ -31,7 +37,24 @@ const SelectAccountArea = ({
 
   const handleAccountChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const selectedValue = e.target.value;
-    setAccount(selectedValue === '' ? null : selectedValue);
+    if (selectedValue === '') {
+      setGroup(null);
+    } else {
+      const selectedGroup = myGroups.find(
+        (group) => group.uuid === selectedValue,
+      );
+      console.log('selectedGroup', selectedGroup);
+      if (!selectedGroup) {
+        setGroup(null);
+        return;
+      }
+      const groupData = {
+        uuid: selectedGroup?.uuid,
+        name: selectedGroup?.name,
+        profileImageUrl: selectedGroup?.profileImageUrl || null,
+      };
+      setGroup(groupData);
+    }
   };
 
   const handleGroupLogin = () => {
@@ -84,10 +107,10 @@ const SelectAccountArea = ({
       </div>
 
       <select
-        value={account ?? ''}
+        value={group?.uuid ?? ''}
         onChange={handleAccountChange}
         className={`w-full appearance-none rounded-[10px] bg-greyLight px-4 py-3.5 ${
-          account ? 'text-primary' : 'text-greyDark'
+          group ? 'text-primary' : 'text-greyDark'
         } focus:border-primary focus:outline-none`}
       >
         <option value="">{t('write.writeAsMyself')}</option>

--- a/src/app/[lng]/write/SelectAccountArea.tsx
+++ b/src/app/[lng]/write/SelectAccountArea.tsx
@@ -1,13 +1,14 @@
 'use client';
 
-import { useEffect } from 'react';
+import { use, useEffect } from 'react';
 import { useState } from 'react';
 
-import { getMyGroups, GroupInfo } from '@/api/group/group';
+import { thirdPartyAuth ,getGroupsToken, getMyGroups, GroupInfo } from '@/api/group/group';
 import { PropsWithT } from '@/app/i18next';
 import NavArrowRightIcon from '@/assets/icons/nav-arrow-right.svg';
 
 import { EditorAction } from './noticeEditorActions';
+import { usePathname } from 'next/navigation';
 
 interface SelectAccountAreaProps {
   account: string | null;
@@ -20,10 +21,12 @@ const SelectAccountArea = ({
   t,
 }: PropsWithT<SelectAccountAreaProps>) => {
   const [myGroups, setMyGroups] = useState<GroupInfo[]>([]);
-
+  const path: string = usePathname();
   useEffect(() => {
-    getMyGroups().then(setMyGroups);
-  }, []);
+    thirdPartyAuth(path);
+    getGroupsToken();
+    getMyGroups().then();
+  }, [path]);
 
   const handleAccountChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const selectedValue = e.target.value;

--- a/src/app/[lng]/write/SelectAccountArea.tsx
+++ b/src/app/[lng]/write/SelectAccountArea.tsx
@@ -1,14 +1,19 @@
 'use client';
 
-import { use, useEffect } from 'react';
-import { useState } from 'react';
+import { usePathname } from 'next/navigation';
+import Swal from 'sweetalert2';
+import { use, useEffect, useState } from 'react';
 
-import { thirdPartyAuth ,getGroupsToken, getMyGroups, GroupInfo } from '@/api/group/group';
+import {
+  getGroupsToken,
+  getMyGroups,
+  GroupInfo,
+  thirdPartyAuth,
+} from '@/api/group/group';
 import { PropsWithT } from '@/app/i18next';
 import NavArrowRightIcon from '@/assets/icons/nav-arrow-right.svg';
 
 import { EditorAction } from './noticeEditorActions';
-import { usePathname } from 'next/navigation';
 
 interface SelectAccountAreaProps {
   account: string | null;
@@ -21,17 +26,37 @@ const SelectAccountArea = ({
   t,
 }: PropsWithT<SelectAccountAreaProps>) => {
   const [myGroups, setMyGroups] = useState<GroupInfo[]>([]);
+  const [isModalOpen, setIsModalOpen] = useState<Boolean>(false);
   const path: string = usePathname();
-  useEffect(() => {
-    thirdPartyAuth(path);
-    getGroupsToken();
-    getMyGroups().then();
-  }, [path]);
+
+  // useEffect(() => {
+  //   thirdPartyAuth(path);
+  //   //TODO: Make Login Hub page for get authrization code
+  //   getGroupsToken('temporary code');
+  // }, [path]);
 
   const handleAccountChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const selectedValue = e.target.value;
     setAccount(selectedValue === '' ? null : selectedValue);
+    if (selectedValue === 'groupSelect') {
+      setIsModalOpen(true);
+    }
   };
+
+  useEffect(() => {
+    isModalOpen &&
+      Swal.fire({
+        title: 'Redirecting',
+        text: 'Do you want to get group information?',
+        icon: 'info',
+        showCancelButton: true,
+      }).then((result) => {
+        if (result.isConfirmed) {
+          thirdPartyAuth(path);
+        }
+        setIsModalOpen(false);
+      });
+  }, [path, isModalOpen]);
 
   return (
     <div className="relative mt-2">
@@ -47,6 +72,7 @@ const SelectAccountArea = ({
         } focus:border-primary focus:outline-none`}
       >
         <option value="">{t('write.writeAsMyself')}</option>
+        <option value="groupSelect">If you want write as a group</option>
 
         {myGroups.map((group) => (
           <option key={group.uuid} value={group.uuid}>

--- a/src/app/[lng]/write/SelectAccountArea.tsx
+++ b/src/app/[lng]/write/SelectAccountArea.tsx
@@ -98,16 +98,17 @@ const SelectAccountArea = ({
             </option>
           ))}
       </select>
-
-      <Button
-        variant="contained"
-        className="w-30 my-4 rounded-[10px] py-2"
-        onClick={handleGroupLogin}
-      >
-        <p className="mx-3 my-1 text-base font-bold">
-          Clike here if you want to write as group
-        </p>
-      </Button>
+      {myGroups.length === 0 ? (
+        <Button
+          variant="contained"
+          className="w-30 my-4 rounded-[10px] py-2"
+          onClick={handleGroupLogin}
+        >
+          <p className="mx-3 my-1 text-base font-bold">
+            Clike here if you want to write as group
+          </p>
+        </Button>
+      ) : null}
     </div>
   );
 };

--- a/src/app/[lng]/write/SelectAccountArea.tsx
+++ b/src/app/[lng]/write/SelectAccountArea.tsx
@@ -53,19 +53,30 @@ const SelectAccountArea = ({
         setIsModalOpen(false);
       });
   }, [path, isModalOpen]);
-
   const thirdPartycode = localStorage.getItem('thirdPartycode');
+  const acessToken = localStorage.getItem('groupsAccessToken');
   useEffect(() => {
     const handleThirdPartyCode = async () => {
       if (thirdPartycode) {
         const data = await getGroupsToken(thirdPartycode);
-        localStorage.removeItem('thirdPartycode');
-        console.log(data.token);
+        console.log(data);
+        if (data) {
+          localStorage.setItem('groupsAccessToken', data.accessToken);
+        }
       }
-      handleThirdPartyCode();
     };
+    handleThirdPartyCode();
   }, [thirdPartycode]);
-
+  useEffect(() => {
+    getMyGroups(acessToken!)
+      .then((data) => {
+        console.log('data', data);
+        setMyGroups(data);
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+  }, [acessToken]);
   return (
     <div className="relative mt-2">
       <div className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2">

--- a/src/app/[lng]/write/handle-notice-submit.ts
+++ b/src/app/[lng]/write/handle-notice-submit.ts
@@ -22,7 +22,11 @@ export interface NoticeSubmitForm {
   tags: string[];
   images: File[];
   category: (typeof Category)[keyof typeof Category];
-  groupId: string | null;
+  group: {
+    uuid: string;
+    name: string;
+    profileImageUrl: string | null;
+  } | null;
 }
 
 export const TITLE_MAX_LENGTH = 50;
@@ -38,7 +42,7 @@ const handleNoticeSubmit = async ({
   tags,
   images,
   category,
-  groupId,
+  group,
   t,
 }: NoticeSubmitForm & { t: T }) => {
   const warningSwal = WarningSwal(t);
@@ -202,7 +206,7 @@ const handleNoticeSubmit = async ({
     images: imageKeys,
     tags: tagIds,
     category,
-    groupId,
+    group,
   }).catch(() => null);
 
   if (!notice) {

--- a/src/app/[lng]/write/noticeEditorActions.ts
+++ b/src/app/[lng]/write/noticeEditorActions.ts
@@ -22,7 +22,11 @@ export interface EditorState {
   tags: Tag[];
   photos: FileWithUrl[];
   isLoading: boolean;
-  account: string | null;
+  group: {
+    uuid: string;
+    name: string;
+    profileImageUrl: string | null;
+  } | null;
 }
 
 export const initialEditorState: EditorState = {
@@ -38,7 +42,7 @@ export const initialEditorState: EditorState = {
   tags: [],
   photos: [],
   isLoading: false,
-  account: null,
+  group: null,
 };
 
 export type EditorAction =
@@ -58,7 +62,14 @@ export type EditorAction =
       type: 'SET_ADDITIONAL_ENGLISH_CONTENT';
       additionalEnglishContent: string;
     }
-  | { type: 'SET_ACCOUNT'; account: string | null };
+  | {
+      type: 'SET_ACCOUNT';
+      group: {
+        uuid: string;
+        name: string;
+        profileImageUrl: string | null;
+      } | null;
+    };
 
 export const editorStateReducer = (
   state: EditorState,
@@ -155,7 +166,7 @@ export const editorStateReducer = (
       };
     }
     case 'SET_ACCOUNT':
-      return { ...state, account: action.account };
+      return { ...state, group: action.group };
     default:
       return state;
   }

--- a/src/app/components/shared/Zabo/Zabo.tsx
+++ b/src/app/components/shared/Zabo/Zabo.tsx
@@ -36,14 +36,13 @@ const Zabo = async (props: ZaboProps & PropsWithLng) => {
     tags,
     lng,
     id,
-    groupId,
+    group,
   } = props;
   const timeAgo = dayjs(createdAt).fromNow();
 
   const hasImage = imageUrls.length > 0;
 
-  const groupInfo = groupId ? await getGroup(groupId) : null;
-
+  console.log('group', group);
   return (
     <Link href={`/${lng}/notice/${id}`}>
       <div
@@ -52,19 +51,19 @@ const Zabo = async (props: ZaboProps & PropsWithLng) => {
         }
       >
         <div className={'mx-3 my-[10px] flex flex-wrap items-center gap-y-3'}>
-          {groupInfo?.profileImageUrl ? (
+          {group?.profileImageUrl ? (
             <Image
-              src={groupInfo.profileImageUrl}
+              src={group.profileImageUrl}
               width={36}
               height={36}
-              alt={groupInfo.name}
+              alt={group.name}
               className={'rounded-full'}
             />
           ) : (
             <DefaultProfile width={36} height={36} />
           )}
           <span className={'ml-2 text-lg font-medium dark:text-dark_white'}>
-            {groupInfo ? groupInfo.name : author.name}
+            {group ? group.name : author.name}
           </span>
 
           <span className={'mx-[5px] font-bold text-greyDark dark:text-grey'}>


### PR DESCRIPTION
- 자신이 속한 그룹을 가져오는 feature가 추가되었습니다.
- thirdpatry token 로직에 추가되었습니다.
- 공지 작성시에 account를 선택하는 컴포넌트 아래에 groups client 로그인을 위한 버튼이 만들어졌습니다.(UI 수정 필요)
- 그룹스에서 지글로 리다이렉트 시킬  때 authcode가 query에 있다면 localstorage에 저장되어 있던 URI로 이동합니다.
- notice 데이터의 group 관련 field가 벡엔드에 맞추어 변경되었습니다.
