### PR TITLE
feat: add service status check link

### DIFF
--- a/src/api/log/log-events.ts
+++ b/src/api/log/log-events.ts
@@ -29,6 +29,7 @@ const LogEvents = {
   footerClickHouse: 'footer_click_house',
   footerClickGist: 'footer_click_gist',
   footerClickGijol: 'footer_click_gijol',
+  footerClickServiceStatus: 'footer_click_service_status',
 
   // Sidebar
   sidebarClickLink: 'sidebar_click_link',

--- a/src/app/components/layout/Footer/Footer.tsx
+++ b/src/app/components/layout/Footer/Footer.tsx
@@ -32,7 +32,8 @@ interface FooterLink {
     | 'contact'
     | 'house'
     | 'gist'
-    | 'gijol';
+    | 'gijol'
+    | 'serviceStatus';
 }
 
 const Footer = async ({ lng }: PropsWithLng) => {

--- a/src/app/components/layout/Footer/keyToLogEvent.ts
+++ b/src/app/components/layout/Footer/keyToLogEvent.ts
@@ -12,6 +12,7 @@ const keyToLogEvent = {
   house: LogEvents.footerClickHouse,
   gist: LogEvents.footerClickGist,
   gijol: LogEvents.footerClickGijol,
+  serviceStatus: LogEvents.footerClickServiceStatus,
 };
 
 export default keyToLogEvent;

--- a/src/app/i18next/locales/en/translation.json
+++ b/src/app/i18next/locales/en/translation.json
@@ -53,6 +53,11 @@
             "name": "Bug Report",
             "link": "https://cs.gistory.me/?service=Ziggle",
             "key": "bugReport"
+          },
+          {
+            "name": "Service Status Check",
+            "link": "https://uptime.icarus.gistory.me/status/ziggle",
+            "key": "serviceStatus"
           }
         ]
       },

--- a/src/app/i18next/locales/ko/translation.json
+++ b/src/app/i18next/locales/ko/translation.json
@@ -49,6 +49,11 @@
             "name": "버그 제보",
             "link": "https://cs.gistory.me/?service=Ziggle",
             "key": "bugReport"
+          },
+          {
+            "name": "서비스 상태 확인",
+            "link": "https://uptime.icarus.gistory.me/status/ziggle",
+            "key": "serviceStatus"
           }
         ]
       },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 푸터 ‘소개’ 섹션에 ‘서비스 상태 확인’ 링크가 추가되어 서비스 가용성 페이지로 바로 이동할 수 있습니다.
  - 한국어·영어 번역이 포함되어 다국어 환경에서 동일하게 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->