### PR TITLE
fix: replace text of landing page title and login button

### DIFF
--- a/src/app/i18next/locales/en/translation.json
+++ b/src/app/i18next/locales/en/translation.json
@@ -1,8 +1,8 @@
 {
   "lang": "en",
   "home": {
-    "login": "Login with GIST account",
-    "subtitle": "Ziggle for GISTians"
+    "login": "Login with Infoteam account",
+    "subtitle": "All GIST's announcements at a glance"
   },
   "metadata": {
     "title": "Ziggle",

--- a/src/app/i18next/locales/ko/translation.json
+++ b/src/app/i18next/locales/ko/translation.json
@@ -2,8 +2,8 @@
 
   "lang": "ko",
   "home": {
-    "login": "GIST 계정으로 로그인",
-    "subtitle": "지스트이언을 위한 지글"
+    "login": "인포팀 계정으로 로그인",
+    "subtitle": "지스트의 모든 공지를 한눈에"
   },
   "metadata": {
     "title": "지글",


### PR DESCRIPTION
랜딩 페이지에 있는 로그인 버튼이랑 제목을 변경했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 번역 업데이트

* **번역 업데이트**
  * 로그인 버튼 텍스트를 "GIST 계정으로 로그인"에서 "Infoteam 계정으로 로그인"으로 변경
  * 홈 페이지 부제목을 업데이트하여 서비스 설명 개선 ("지스트의 모든 공지를 한눈에")
  * 한국어 및 영어 버전 동시 적용

<!-- end of auto-generated comment: release notes by coderabbit.ai -->