### PR TITLE
Customize chatbot appearance with primary color

### DIFF
--- a/src/app/[lng]/layout.tsx
+++ b/src/app/[lng]/layout.tsx
@@ -127,6 +127,9 @@ export default async function RootLayout({
           src="https://chatbot.gistory.me/loader.js"
           data-widget-key={process.env.NEXT_PUBLIC_CHATBOT_WIDGET_KEY}
           data-button-icon="logo"
+          data-primary-color="ff4500"
+          data-button-color="ff4500"
+          data-user-message-bg="ff4500"
         />
       )}
     </html>


### PR DESCRIPTION
챗봇 위젯 색깔(위젯, 전송 버튼, 말풍선)을 #FF4500으로 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 챗봇 위젯의 색상 사용자 정의 기능이 추가되었습니다. 주색상, 버튼 색상, 사용자 메시지 배경 색상을 설정할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->