### PR TITLE
feat: display document urls and source url in notice detail

### DIFF
--- a/public/locales/en/notice.json
+++ b/public/locales/en/notice.json
@@ -22,6 +22,8 @@
       "content": "{{title}}\n\nCheck the notice in Ziggle!\n{{- link}}",
       "success": "The notice link has been copied!<small>Share the notice with your friends.</small>"
     },
+    "attachments": "Attachments",
+    "source_url": "Source URL",
     "download_all": "Download All",
     "due_at": "Due at {{dueAt}}",
     "no_content": "No Content",

--- a/public/locales/ko/notice.json
+++ b/public/locales/ko/notice.json
@@ -22,6 +22,8 @@
       "content": "{{title}}\n\nZiggle에서 공지를 확인해주세요\n{{- link}}",
       "success": "공지 주소가 복사되었습니다!<small>친구들에게 공지를 공유해보세요</small>"
     },
+    "attachments": "첨부파일",
+    "source_url": "원본링크",
     "download_all": "전체 다운로드하기",
     "due_at": "마감시간 {{dueAt}}",
     "no_content": "내용 없음",

--- a/src/features/notice/views/components/additional-notices.stories.tsx
+++ b/src/features/notice/views/components/additional-notices.stories.tsx
@@ -18,8 +18,10 @@ const mockNotice: NoticeDetail = {
   deadline: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
   publishedAt: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
   imageUrls: [],
-  documentUrls: [],
+  documents: [],
   additionalContents: [],
+  isViewed: false,
+  isBookmarked: false,
 };
 
 const mockAdditionalContents: AdditionalContent[] = [

--- a/src/features/notice/views/components/document-urls.stories.tsx
+++ b/src/features/notice/views/components/document-urls.stories.tsx
@@ -1,0 +1,50 @@
+import { DocumentUrls } from './document-urls';
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta = {
+  title: 'Features/Notice/DocumentUrls',
+  component: DocumentUrls,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof DocumentUrls>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const AttachmentsOnly: Story = {
+  args: {
+    documentUrls: [
+      'https://www.gist.ac.kr/kr/attachments/첨부파일_제목1.pdf',
+      'https://www.gist.ac.kr/kr/attachments/첨부파일_제목2.pdf',
+      'https://www.gist.ac.kr/kr/attachments/첨부파일_제목3.pdf',
+    ],
+  },
+};
+
+export const SourceUrlOnly: Story = {
+  args: {
+    sourceUrl: 'https://www.gist.ac.kr/kr/html/sub05/050502.html',
+    documentUrls: [],
+  },
+};
+
+export const Both: Story = {
+  args: {
+    sourceUrl: 'https://www.gist.ac.kr/kr/html/sub05/050502.html',
+    documentUrls: [
+      'https://www.gist.ac.kr/kr/attachments/첨부파일_제목1.pdf',
+      'https://www.gist.ac.kr/kr/attachments/첨부파일_제목2.pdf',
+      'https://www.gist.ac.kr/kr/attachments/첨부파일_제목3.pdf',
+    ],
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    documentUrls: [],
+  },
+};

--- a/src/features/notice/views/components/document-urls.stories.tsx
+++ b/src/features/notice/views/components/document-urls.stories.tsx
@@ -17,10 +17,19 @@ type Story = StoryObj<typeof meta>;
 
 export const AttachmentsOnly: Story = {
   args: {
-    documentUrls: [
-      'https://www.gist.ac.kr/kr/attachments/첨부파일_제목1.pdf',
-      'https://www.gist.ac.kr/kr/attachments/첨부파일_제목2.pdf',
-      'https://www.gist.ac.kr/kr/attachments/첨부파일_제목3.pdf',
+    documents: [
+      {
+        url: 'https://www.gist.ac.kr/kr/attachments/document1.pdf',
+        name: '첨부파일_제목1.pdf',
+      },
+      {
+        url: 'https://www.gist.ac.kr/kr/attachments/document2.pdf',
+        name: '첨부파일_제목2.pdf',
+      },
+      {
+        url: 'https://www.gist.ac.kr/kr/attachments/document3.pdf',
+        name: '첨부파일_제목3.pdf',
+      },
     ],
   },
 };
@@ -28,23 +37,32 @@ export const AttachmentsOnly: Story = {
 export const SourceUrlOnly: Story = {
   args: {
     crawledUrl: 'https://www.gist.ac.kr/kr/html/sub05/050502.html',
-    documentUrls: [],
+    documents: [],
   },
 };
 
 export const Both: Story = {
   args: {
     crawledUrl: 'https://www.gist.ac.kr/kr/html/sub05/050502.html',
-    documentUrls: [
-      'https://www.gist.ac.kr/kr/attachments/첨부파일_제목1.pdf',
-      'https://www.gist.ac.kr/kr/attachments/첨부파일_제목2.pdf',
-      'https://www.gist.ac.kr/kr/attachments/첨부파일_제목3.pdf',
+    documents: [
+      {
+        url: 'https://www.gist.ac.kr/kr/attachments/document1.pdf',
+        name: '첨부파일_제목1.pdf',
+      },
+      {
+        url: 'https://www.gist.ac.kr/kr/attachments/document2.pdf',
+        name: '첨부파일_제목2.pdf',
+      },
+      {
+        url: 'https://www.gist.ac.kr/kr/attachments/document3.pdf',
+        name: '첨부파일_제목3.pdf',
+      },
     ],
   },
 };
 
 export const Empty: Story = {
   args: {
-    documentUrls: [],
+    documents: [],
   },
 };

--- a/src/features/notice/views/components/document-urls.stories.tsx
+++ b/src/features/notice/views/components/document-urls.stories.tsx
@@ -61,6 +61,23 @@ export const Both: Story = {
   },
 };
 
+export const LongFileName: Story = {
+  args: {
+    crawledUrl:
+      'https://www.gist.ac.kr/kr/html/sub05/very_long_path_without_any_spaces_to_force_break_all_behavior_test.html',
+    documents: [
+      {
+        url: 'https://www.gist.ac.kr/kr/attachments/document1.pdf',
+        name: 'extremely_long_attachment_filename_without_any_spaces_or_breakpoints_to_verify_break_all_layout_handling.pdf',
+      },
+      {
+        url: 'https://www.gist.ac.kr/kr/attachments/document2.pdf',
+        name: '띄어쓰기없는한글로된아주아주아주아주긴첨부파일제목으로레이아웃넘침을확인하는테스트케이스.pdf',
+      },
+    ],
+  },
+};
+
 export const Empty: Story = {
   args: {
     documents: [],

--- a/src/features/notice/views/components/document-urls.stories.tsx
+++ b/src/features/notice/views/components/document-urls.stories.tsx
@@ -27,14 +27,14 @@ export const AttachmentsOnly: Story = {
 
 export const SourceUrlOnly: Story = {
   args: {
-    sourceUrl: 'https://www.gist.ac.kr/kr/html/sub05/050502.html',
+    crawledUrl: 'https://www.gist.ac.kr/kr/html/sub05/050502.html',
     documentUrls: [],
   },
 };
 
 export const Both: Story = {
   args: {
-    sourceUrl: 'https://www.gist.ac.kr/kr/html/sub05/050502.html',
+    crawledUrl: 'https://www.gist.ac.kr/kr/html/sub05/050502.html',
     documentUrls: [
       'https://www.gist.ac.kr/kr/attachments/첨부파일_제목1.pdf',
       'https://www.gist.ac.kr/kr/attachments/첨부파일_제목2.pdf',

--- a/src/features/notice/views/components/document-urls.tsx
+++ b/src/features/notice/views/components/document-urls.tsx
@@ -40,7 +40,7 @@ export function DocumentUrls({
                   href={url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-secondaryText underline"
+                  className="text-secondaryText break-all underline"
                 >
                   {name}
                 </a>

--- a/src/features/notice/views/components/document-urls.tsx
+++ b/src/features/notice/views/components/document-urls.tsx
@@ -1,0 +1,80 @@
+import { Link, Paperclip } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+function getFileName(url: string): string {
+  try {
+    const pathname = new URL(url).pathname;
+    const name = pathname.split('/').pop();
+    return name ? decodeURIComponent(name) : url;
+  } catch {
+    return url;
+  }
+}
+
+interface DocumentUrlsProps {
+  // TODO(ZGB-51): 백엔드 sourceUrl 필드 추가 후 gen:api 재실행 및 notice-info.tsx에서 전달 필요
+  sourceUrl?: string;
+  documentUrls: string[];
+}
+
+export function DocumentUrls({ sourceUrl, documentUrls }: DocumentUrlsProps) {
+  const { t } = useTranslation('notice');
+
+  if (!sourceUrl && documentUrls.length === 0) return null;
+
+  return (
+    <div className="border-greyLight border-y py-3">
+      <div className="grid grid-cols-[max-content_1fr] items-start gap-x-6 gap-y-3">
+        {sourceUrl && (
+          <>
+            <Label icon={<Link size={18} />}>{t('detail.source_url')}</Label>
+            <a
+              href={sourceUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-secondaryText break-all underline"
+            >
+              {sourceUrl}
+            </a>
+          </>
+        )}
+
+        {documentUrls.length > 0 && (
+          <>
+            <Label icon={<Paperclip size={18} />}>
+              {t('detail.attachments')}
+            </Label>
+            <div className="flex flex-col gap-1">
+              {documentUrls.map((url) => (
+                <a
+                  key={url}
+                  href={url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-secondaryText underline"
+                >
+                  {getFileName(url)}
+                </a>
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Label({
+  icon,
+  children,
+}: {
+  icon: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="text-greyDark dark:text-dark_greyLight flex items-center gap-1.5 font-medium">
+      {icon}
+      <span>{children}</span>
+    </div>
+  );
+}

--- a/src/features/notice/views/components/document-urls.tsx
+++ b/src/features/notice/views/components/document-urls.tsx
@@ -1,6 +1,8 @@
 import { Link, Paperclip } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
+// TODO: file name 추후 백엔드에서 전달할 예정
+
 function getFileName(url: string): string {
   try {
     const pathname = new URL(url).pathname;
@@ -12,29 +14,28 @@ function getFileName(url: string): string {
 }
 
 interface DocumentUrlsProps {
-  // TODO(ZGB-51): 백엔드 sourceUrl 필드 추가 후 gen:api 재실행 및 notice-info.tsx에서 전달 필요
-  sourceUrl?: string;
+  crawledUrl?: string;
   documentUrls: string[];
 }
 
-export function DocumentUrls({ sourceUrl, documentUrls }: DocumentUrlsProps) {
+export function DocumentUrls({ crawledUrl, documentUrls }: DocumentUrlsProps) {
   const { t } = useTranslation('notice');
 
-  if (!sourceUrl && documentUrls.length === 0) return null;
+  if (!crawledUrl && documentUrls.length === 0) return null;
 
   return (
     <div className="border-greyLight border-y py-3">
       <div className="grid grid-cols-[max-content_1fr] items-start gap-x-6 gap-y-3">
-        {sourceUrl && (
+        {crawledUrl && (
           <>
             <Label icon={<Link size={18} />}>{t('detail.source_url')}</Label>
             <a
-              href={sourceUrl}
+              href={crawledUrl}
               target="_blank"
               rel="noopener noreferrer"
               className="text-secondaryText break-all underline"
             >
-              {sourceUrl}
+              {crawledUrl}
             </a>
           </>
         )}

--- a/src/features/notice/views/components/document-urls.tsx
+++ b/src/features/notice/views/components/document-urls.tsx
@@ -1,27 +1,15 @@
 import { Link, Paperclip } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
-// TODO: file name 추후 백엔드에서 전달할 예정
+import type { NoticeDetail } from '../../models';
 
-function getFileName(url: string): string {
-  try {
-    const pathname = new URL(url).pathname;
-    const name = pathname.split('/').pop();
-    return name ? decodeURIComponent(name) : url;
-  } catch {
-    return url;
-  }
-}
-
-interface DocumentUrlsProps {
-  crawledUrl?: string;
-  documentUrls: string[];
-}
-
-export function DocumentUrls({ crawledUrl, documentUrls }: DocumentUrlsProps) {
+export function DocumentUrls({
+  crawledUrl,
+  documents,
+}: Pick<NoticeDetail, 'crawledUrl' | 'documents'>) {
   const { t } = useTranslation('notice');
 
-  if (!crawledUrl && documentUrls.length === 0) return null;
+  if (!crawledUrl && documents.length === 0) return null;
 
   return (
     <div className="border-greyLight border-y py-3">
@@ -40,13 +28,13 @@ export function DocumentUrls({ crawledUrl, documentUrls }: DocumentUrlsProps) {
           </>
         )}
 
-        {documentUrls.length > 0 && (
+        {documents.length > 0 && (
           <>
             <Label icon={<Paperclip size={18} />}>
               {t('detail.attachments')}
             </Label>
             <div className="flex flex-col gap-1">
-              {documentUrls.map((url) => (
+              {documents.map(({ url, name }) => (
                 <a
                   key={url}
                   href={url}
@@ -54,7 +42,7 @@ export function DocumentUrls({ crawledUrl, documentUrls }: DocumentUrlsProps) {
                   rel="noopener noreferrer"
                   className="text-secondaryText underline"
                 >
-                  {getFileName(url)}
+                  {name}
                 </a>
               ))}
             </div>

--- a/src/features/notice/views/components/zabo/attachment-indicators.tsx
+++ b/src/features/notice/views/components/zabo/attachment-indicators.tsx
@@ -1,0 +1,38 @@
+import { Link as LinkIcon, Paperclip } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import type { Notice } from '@/features/notice/models';
+
+export function AttachmentIndicators({
+  documents,
+  crawledUrl,
+}: Pick<Notice, 'documents' | 'crawledUrl'>) {
+  const { t } = useTranslation('notice');
+
+  const hasDocuments = documents.length > 0;
+  const hasSourceUrl = Boolean(crawledUrl);
+
+  if (!hasDocuments && !hasSourceUrl) return null;
+
+  return (
+    <div className="text-greyDark dark:text-grey flex items-center gap-3 text-sm font-medium">
+      {hasDocuments && (
+        <span
+          className="flex items-center gap-1"
+          aria-label={t('detail.attachments')}
+        >
+          <Paperclip size={16} />
+          <span>{documents.length}</span>
+        </span>
+      )}
+      {hasSourceUrl && (
+        <span
+          className="flex items-center gap-1"
+          aria-label={t('detail.source_url')}
+        >
+          <LinkIcon size={16} />
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/features/notice/views/components/zabo/result-image-zabo.stories.tsx
+++ b/src/features/notice/views/components/zabo/result-image-zabo.stories.tsx
@@ -28,7 +28,9 @@ const mockNotice: ResultZaboProps = {
   isReminded: false,
   category: {},
   publishedAt: new Date().toISOString(),
-  documentUrls: [],
+  documents: [],
+  isViewed: false,
+  isBookmarked: false,
 };
 
 const queryClient = new QueryClient();

--- a/src/features/notice/views/components/zabo/result-image-zabo.tsx
+++ b/src/features/notice/views/components/zabo/result-image-zabo.tsx
@@ -4,6 +4,7 @@ import dayjs from 'dayjs';
 
 import DefaultProfile from '@/assets/icons/default-profile.svg?react';
 
+import { AttachmentIndicators } from './attachment-indicators';
 import DDay from './d-day';
 import { HighlightedText } from './highlighted-text';
 import { ZaboActions } from './zabo-actions';
@@ -19,6 +20,8 @@ export const ResultImageZabo = (props: ResultZaboProps) => {
     createdAt,
     imageUrls,
     searchQuery,
+    documents,
+    crawledUrl,
   } = props;
   return (
     <Link className="min-w-fit" to="/notice/$id" params={{ id: id.toString() }}>
@@ -56,12 +59,20 @@ export const ResultImageZabo = (props: ResultZaboProps) => {
             <DDay deadline={currentDeadline} className="text-xs md:text-sm" />
           )}
         </div>
-        <div className="dark:text-dark_white text-xl font-semibold">
-          {searchQuery ? (
-            <HighlightedText query={searchQuery}>{title}</HighlightedText>
-          ) : (
-            title
-          )}
+        <div className="flex items-baseline gap-2">
+          <div className="dark:text-dark_white text-xl font-semibold">
+            {searchQuery ? (
+              <HighlightedText query={searchQuery}>{title}</HighlightedText>
+            ) : (
+              title
+            )}
+          </div>
+          <div className="shrink-0">
+            <AttachmentIndicators
+              documents={documents}
+              crawledUrl={crawledUrl}
+            />
+          </div>
         </div>
         <div className="scrollbar scrollbar-thumb-greyBorder scrollbar-thumb-rounded-full scrollbar-h-1 flex gap-2 overflow-x-scroll py-1">
           {imageUrls.map((url, i) => (

--- a/src/features/notice/views/components/zabo/result-text-zabo.stories.tsx
+++ b/src/features/notice/views/components/zabo/result-text-zabo.stories.tsx
@@ -26,7 +26,9 @@ const mockNotice: ResultZaboProps = {
   isReminded: false,
   category: {},
   publishedAt: new Date().toISOString(),
-  documentUrls: [],
+  documents: [],
+  isViewed: false,
+  isBookmarked: false,
 };
 
 const queryClient = new QueryClient();

--- a/src/features/notice/views/components/zabo/result-text-zabo.tsx
+++ b/src/features/notice/views/components/zabo/result-text-zabo.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 
 import DefaultProfile from '@/assets/icons/default-profile.svg?react';
 
+import { AttachmentIndicators } from './attachment-indicators';
 import DDay from './d-day';
 import { HighlightedText } from './highlighted-text';
 import { ZaboActions } from './zabo-actions';
@@ -20,6 +21,8 @@ export const ResultTextZabo = (props: ResultZaboProps) => {
     createdAt,
     content,
     searchQuery,
+    documents,
+    crawledUrl,
   } = props;
 
   const { t } = useTranslation('notice');
@@ -60,12 +63,20 @@ export const ResultTextZabo = (props: ResultZaboProps) => {
             <DDay deadline={currentDeadline} className="text-xs md:text-sm" />
           )}
         </div>
-        <div className="dark:text-dark_white text-xl font-semibold">
-          {searchQuery ? (
-            <HighlightedText query={searchQuery}>{title}</HighlightedText>
-          ) : (
-            title
-          )}
+        <div className="flex items-baseline gap-2">
+          <div className="dark:text-dark_white text-xl font-semibold">
+            {searchQuery ? (
+              <HighlightedText query={searchQuery}>{title}</HighlightedText>
+            ) : (
+              title
+            )}
+          </div>
+          <div className="shrink-0">
+            <AttachmentIndicators
+              documents={documents}
+              crawledUrl={crawledUrl}
+            />
+          </div>
         </div>
         <div className="font-regular dark:text-dark_white line-clamp-4 text-start text-ellipsis">
           {searchQuery ? (

--- a/src/features/notice/views/components/zabo/result-zabo.stories.tsx
+++ b/src/features/notice/views/components/zabo/result-zabo.stories.tsx
@@ -25,7 +25,9 @@ const mockNotice: ResultZaboProps = {
   isReminded: false,
   category: {},
   publishedAt: new Date().toISOString(),
-  documentUrls: [],
+  documents: [],
+  isViewed: false,
+  isBookmarked: false,
 };
 
 const queryClient = new QueryClient();

--- a/src/features/notice/views/components/zabo/zabo-tags.stories.tsx
+++ b/src/features/notice/views/components/zabo/zabo-tags.stories.tsx
@@ -19,7 +19,9 @@ const mockNotice: Notice = {
   isReminded: false,
   category: {},
   publishedAt: new Date().toISOString(),
-  documentUrls: [],
+  documents: [],
+  isViewed: false,
+  isBookmarked: false,
 };
 
 const meta = {

--- a/src/features/notice/views/components/zabo/zabo.stories.tsx
+++ b/src/features/notice/views/components/zabo/zabo.stories.tsx
@@ -109,3 +109,13 @@ export const WithPicture: Story = {
     },
   },
 };
+
+export const WithDocumentUrls: Story = {
+  args: {
+    ...mockNotice,
+    documentUrls: [
+      'https://www.gist.ac.kr/kr/attachments/첨부파일_제목1.pdf',
+      'https://www.gist.ac.kr/kr/attachments/첨부파일_제목2.pdf',
+    ],
+  },
+};

--- a/src/features/notice/views/components/zabo/zabo.stories.tsx
+++ b/src/features/notice/views/components/zabo/zabo.stories.tsx
@@ -127,3 +127,27 @@ export const WithDocuments: Story = {
     ],
   },
 };
+
+export const WithCrawledUrl: Story = {
+  args: {
+    ...mockNotice,
+    crawledUrl: 'https://www.gist.ac.kr/kr/html/sub05/050502.html',
+  },
+};
+
+export const WithDocumentsAndCrawledUrl: Story = {
+  args: {
+    ...mockNotice,
+    crawledUrl: 'https://www.gist.ac.kr/kr/html/sub05/050502.html',
+    documents: [
+      {
+        url: 'https://www.gist.ac.kr/kr/attachments/document1.pdf',
+        name: '첨부파일_제목1.pdf',
+      },
+      {
+        url: 'https://www.gist.ac.kr/kr/attachments/document2.pdf',
+        name: '첨부파일_제목2.pdf',
+      },
+    ],
+  },
+};

--- a/src/features/notice/views/components/zabo/zabo.stories.tsx
+++ b/src/features/notice/views/components/zabo/zabo.stories.tsx
@@ -26,7 +26,9 @@ const mockNotice: Notice = {
   isReminded: false,
   category: {},
   publishedAt: new Date().toISOString(),
-  documentUrls: [],
+  documents: [],
+  isViewed: false,
+  isBookmarked: false,
 };
 
 const queryClient = new QueryClient();
@@ -110,12 +112,18 @@ export const WithPicture: Story = {
   },
 };
 
-export const WithDocumentUrls: Story = {
+export const WithDocuments: Story = {
   args: {
     ...mockNotice,
-    documentUrls: [
-      'https://www.gist.ac.kr/kr/attachments/첨부파일_제목1.pdf',
-      'https://www.gist.ac.kr/kr/attachments/첨부파일_제목2.pdf',
+    documents: [
+      {
+        url: 'https://www.gist.ac.kr/kr/attachments/document1.pdf',
+        name: '첨부파일_제목1.pdf',
+      },
+      {
+        url: 'https://www.gist.ac.kr/kr/attachments/document2.pdf',
+        name: '첨부파일_제목2.pdf',
+      },
     ],
   },
 };

--- a/src/features/notice/views/components/zabo/zabo.tsx
+++ b/src/features/notice/views/components/zabo/zabo.tsx
@@ -5,6 +5,7 @@ import dayjs from 'dayjs';
 import { Avatar } from '@/common/components';
 import type { Notice } from '@/features/notice/models';
 
+import { AttachmentIndicators } from './attachment-indicators';
 import DDay from './d-day';
 import { ZaboActions } from './zabo-actions';
 import { ZaboImageCarousel } from './zabo-image-carousel';
@@ -24,8 +25,18 @@ export type ZaboProps = Notice & {
 };
 
 export const Zabo = (props: ZaboProps) => {
-  const { content, createdAt, author, deadline, title, imageUrls, tags, id } =
-    props;
+  const {
+    content,
+    createdAt,
+    author,
+    deadline,
+    title,
+    imageUrls,
+    tags,
+    id,
+    documents,
+    crawledUrl,
+  } = props;
   const timeAgo = dayjs(createdAt).fromNow();
 
   const hasImage = imageUrls.length > 0;
@@ -61,9 +72,17 @@ export const Zabo = (props: ZaboProps) => {
         </div>
 
         <div className="flex w-full flex-col gap-2.5 px-4 pb-2.5">
-          <p className="dark:text-dark_white line-clamp-3 text-xl font-semibold">
-            {title}
-          </p>
+          <div className="flex items-baseline gap-2">
+            <p className="dark:text-dark_white line-clamp-3 text-xl font-semibold">
+              {title}
+            </p>
+            <div className="shrink-0">
+              <AttachmentIndicators
+                documents={documents}
+                crawledUrl={crawledUrl}
+              />
+            </div>
+          </div>
 
           {hasImage && (
             <ZaboImageCarousel imageUrls={imageUrls} title={title} />

--- a/src/features/notice/views/notice-info.stories.tsx
+++ b/src/features/notice/views/notice-info.stories.tsx
@@ -10,7 +10,9 @@ import { NoticeInfo } from './notice-info';
 import type { NoticeDetail } from '../models';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
-const mockNotice: NoticeDetail = {
+type NoticeInfoProps = NoticeDetail & { sourceUrl?: string };
+
+const mockNotice: NoticeInfoProps = {
   id: 1,
   title: '2026 봄 학기 동아리 모집',
   author: { uuid: 'author-1', name: '홍길동', picture: null },
@@ -30,10 +32,10 @@ const mockNotice: NoticeDetail = {
 
 const queryClient = new QueryClient();
 
-const createNoticeInfoRouter = (props: NoticeDetail) => {
+const createNoticeInfoRouter = (props: NoticeInfoProps) => {
   const rootRoute = createRootRoute({
     component: () => (
-      <div className="w-120 p-6">
+      <div className="w-180 p-6">
         <NoticeInfo {...props} />
       </div>
     ),
@@ -41,7 +43,7 @@ const createNoticeInfoRouter = (props: NoticeDetail) => {
   return createRouter({ routeTree: rootRoute });
 };
 
-const NoticeInfoWithProviders = (props: NoticeDetail) => {
+const NoticeInfoWithProviders = (props: NoticeInfoProps) => {
   const router = createNoticeInfoRouter(props);
   return (
     <QueryClientProvider client={queryClient}>
@@ -98,5 +100,17 @@ export const WithPicture: Story = {
       ...mockNotice.author,
       picture: 'https://picsum.photos/seed/author1/36/36',
     },
+  },
+};
+
+export const WithSourceUrlAndDocumentUrls: Story = {
+  args: {
+    ...mockNotice,
+    sourceUrl: 'https://www.gist.ac.kr/kr/html/sub05/050502.html',
+    documentUrls: [
+      'https://www.gist.ac.kr/kr/attachments/첨부파일_제목1.pdf',
+      'https://www.gist.ac.kr/kr/attachments/첨부파일_제목2.pdf',
+      'https://www.gist.ac.kr/kr/attachments/첨부파일_제목3.pdf',
+    ],
   },
 };

--- a/src/features/notice/views/notice-info.stories.tsx
+++ b/src/features/notice/views/notice-info.stories.tsx
@@ -10,7 +10,7 @@ import { NoticeInfo } from './notice-info';
 import type { NoticeDetail } from '../models';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
-type NoticeInfoProps = NoticeDetail & { sourceUrl?: string };
+type NoticeInfoProps = NoticeDetail;
 
 const mockNotice: NoticeInfoProps = {
   id: 1,
@@ -106,7 +106,7 @@ export const WithPicture: Story = {
 export const WithSourceUrlAndDocumentUrls: Story = {
   args: {
     ...mockNotice,
-    sourceUrl: 'https://www.gist.ac.kr/kr/html/sub05/050502.html',
+    crawledUrl: 'https://www.gist.ac.kr/kr/html/sub05/050502.html',
     documentUrls: [
       'https://www.gist.ac.kr/kr/attachments/첨부파일_제목1.pdf',
       'https://www.gist.ac.kr/kr/attachments/첨부파일_제목2.pdf',

--- a/src/features/notice/views/notice-info.stories.tsx
+++ b/src/features/notice/views/notice-info.stories.tsx
@@ -26,8 +26,10 @@ const mockNotice: NoticeInfoProps = {
   category: {},
   publishedAt: new Date().toISOString(),
   imageUrls: [],
-  documentUrls: [],
+  documents: [],
   additionalContents: [],
+  isViewed: false,
+  isBookmarked: false,
 };
 
 const queryClient = new QueryClient();
@@ -107,10 +109,19 @@ export const WithSourceUrlAndDocumentUrls: Story = {
   args: {
     ...mockNotice,
     crawledUrl: 'https://www.gist.ac.kr/kr/html/sub05/050502.html',
-    documentUrls: [
-      'https://www.gist.ac.kr/kr/attachments/첨부파일_제목1.pdf',
-      'https://www.gist.ac.kr/kr/attachments/첨부파일_제목2.pdf',
-      'https://www.gist.ac.kr/kr/attachments/첨부파일_제목3.pdf',
+    documents: [
+      {
+        url: 'https://www.gist.ac.kr/kr/attachments/document1.pdf',
+        name: '첨부파일_제목1.pdf',
+      },
+      {
+        url: 'https://www.gist.ac.kr/kr/attachments/document2.pdf',
+        name: '첨부파일_제목2.pdf',
+      },
+      {
+        url: 'https://www.gist.ac.kr/kr/attachments/document3.pdf',
+        name: '첨부파일_제목3.pdf',
+      },
     ],
   },
 };

--- a/src/features/notice/views/notice-info.stories.tsx
+++ b/src/features/notice/views/notice-info.stories.tsx
@@ -125,3 +125,21 @@ export const WithSourceUrlAndDocumentUrls: Story = {
     ],
   },
 };
+
+export const WithLongFileName: Story = {
+  args: {
+    ...mockNotice,
+    crawledUrl:
+      'https://www.gist.ac.kr/kr/html/sub05/very_long_path_without_any_spaces_to_force_break_all_behavior_test.html',
+    documents: [
+      {
+        url: 'https://www.gist.ac.kr/kr/attachments/document1.pdf',
+        name: 'extremely_long_attachment_filename_without_any_spaces_or_breakpoints_to_verify_break_all_layout_handling.pdf',
+      },
+      {
+        url: 'https://www.gist.ac.kr/kr/attachments/document2.pdf',
+        name: '띄어쓰기없는한글로된아주아주아주아주긴첨부파일제목으로레이아웃넘침을확인하는테스트케이스.pdf',
+      },
+    ],
+  },
+};

--- a/src/features/notice/views/notice-info.tsx
+++ b/src/features/notice/views/notice-info.tsx
@@ -5,6 +5,7 @@ import { Avatar } from '@/common/components';
 import { useUser } from '@/features/auth';
 
 import { AuthorActions } from './components/author-actions';
+import { DocumentUrls } from './components/document-urls';
 import { Tags } from './components/tags';
 
 import type { Author, NoticeDetail } from '../models';
@@ -17,7 +18,10 @@ export const NoticeInfo = ({
   createdAt,
   views,
   tags = [],
-}: NoticeDetail) => {
+  documentUrls,
+  // TODO(ZGB-51): 백엔드 sourceUrl 추가 후 NoticeDetail 타입에서 직접 받고 이 intersection 제거
+  sourceUrl,
+}: NoticeDetail & { sourceUrl?: string }) => {
   const { data: user } = useUser();
 
   return (
@@ -31,6 +35,8 @@ export const NoticeInfo = ({
       <Title title={title} />
 
       <Tags tags={tags} className="flex-wrap" />
+
+      <DocumentUrls sourceUrl={sourceUrl} documentUrls={documentUrls} />
     </div>
   );
 };

--- a/src/features/notice/views/notice-info.tsx
+++ b/src/features/notice/views/notice-info.tsx
@@ -18,7 +18,7 @@ export const NoticeInfo = ({
   createdAt,
   views,
   tags = [],
-  documentUrls,
+  documents,
   crawledUrl,
 }: NoticeDetail) => {
   const { data: user } = useUser();
@@ -35,7 +35,7 @@ export const NoticeInfo = ({
 
       <Tags tags={tags} className="flex-wrap" />
 
-      <DocumentUrls crawledUrl={crawledUrl} documentUrls={documentUrls} />
+      <DocumentUrls crawledUrl={crawledUrl} documents={documents} />
     </div>
   );
 };

--- a/src/features/notice/views/notice-info.tsx
+++ b/src/features/notice/views/notice-info.tsx
@@ -19,9 +19,8 @@ export const NoticeInfo = ({
   views,
   tags = [],
   documentUrls,
-  // TODO(ZGB-51): 백엔드 sourceUrl 추가 후 NoticeDetail 타입에서 직접 받고 이 intersection 제거
-  sourceUrl,
-}: NoticeDetail & { sourceUrl?: string }) => {
+  crawledUrl,
+}: NoticeDetail) => {
   const { data: user } = useUser();
 
   return (
@@ -36,7 +35,7 @@ export const NoticeInfo = ({
 
       <Tags tags={tags} className="flex-wrap" />
 
-      <DocumentUrls sourceUrl={sourceUrl} documentUrls={documentUrls} />
+      <DocumentUrls crawledUrl={crawledUrl} documentUrls={documentUrls} />
     </div>
   );
 };

--- a/src/styles.css
+++ b/src/styles.css
@@ -23,6 +23,7 @@
   --color-dark_greyDark: #3b3b3b;
   --color-dark_greyBorder: #5d5d5d;
   --color-dark_grey: #919191;
+  --color-dark_greyLight: #bebebe;
   --color-dark_white: #ffffff;
   --color-dark_secondary: #432b22;
 


### PR DESCRIPTION

<img width="50%" alt="CleanShot 2026-05-07 at 13 54 28@2x" src="https://github.com/user-attachments/assets/825833d5-b109-43c5-9b51-a84d39e2de36" />

<img width="50%" alt="CleanShot 2026-05-07 at 13 54 20@2x" src="https://github.com/user-attachments/assets/a18cbf8a-cd09-459c-87dc-5366034bc406" />

---

Changelog
- Add DocumentUrls component showing attachments and source link
- Integrate into NoticeInfo below tags section
- Add dark_greyLight (#bebebe) token for label contrast in dark mode
- Add ko/en i18n keys for attachments and source_url
- Add Storybook stories for DocumentUrls and NoticeInfo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 공지사항에 원본 링크(원본링크) 및 첨부파일(첨부파일) 표시 기능 추가
  * 공지 목록 및 상세에서 첨부 표시(아이콘·개수) 및 첨부 링크 표시 추가

* **문서화**
  * 관련 UI 사례(스토리) 및 사용 시나리오 추가

* **스타일**
  * UI 테마 색상 변수(--color-dark_greyLight) 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->